### PR TITLE
Add undo/redo, history UI and autosave

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     <link rel="stylesheet" href="styles/pnml-importer.css">
     <link rel="stylesheet" href="styles/random-generator.css">
     <link rel="stylesheet" href="styles/png-exporter.css">
+    <link rel="stylesheet" href="styles/features.css">
 
     <!-- 
       WebPPL Bundle for Probabilistic Programming
@@ -371,6 +372,10 @@
                         <button id="btn-add-place" title="Add place">○</button>
                         <button id="btn-add-transition" title="Add transition">□</button>
                         <button id="btn-add-arc" title="Add arc - Hotkey: Space">→</button>
+                        <hr>
+                        <button id="btn-undo" title="Undo (Ctrl+Z)" disabled>↩</button>
+                        <button id="btn-redo" title="Redo (Ctrl+Shift+Z)" disabled>↪</button>
+                        <button id="btn-history" title="Action History">📜</button>
                         <hr>
                         <button id="btn-delete" class="danger" title="Delete selected element">🗑️</button>
                         <button id="btn-clear" class="danger" title="Clear canvas">🧹</button>

--- a/public/examples/DPN-Emergency-Triage.json
+++ b/public/examples/DPN-Emergency-Triage.json
@@ -1,0 +1,236 @@
+{
+  "id": "emergency-triage-dpn",
+  "name": "Emergency Department Triage & Treatment",
+  "description": "A data Petri net modelling an emergency department workflow: patient arrives, vitals are assessed, a triage level is assigned based on severity, diagnostic tests are ordered, treatment is chosen based on diagnosis, and the patient is either discharged or admitted to the hospital. Uses 5 data variables with guard-based branching.",
+  "places": [
+    { "id": "p_start", "position": { "x": 60, "y": 300 }, "label": "Patient Arrival", "tokens": 1, "capacity": null, "finalMarking": 0, "radius": 20 },
+    { "id": "p_registered", "position": { "x": 220, "y": 300 }, "label": "Registered", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
+    { "id": "p_vitals_taken", "position": { "x": 400, "y": 300 }, "label": "Vitals Assessed", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
+    { "id": "p_triaged", "position": { "x": 580, "y": 300 }, "label": "Triaged", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
+
+    { "id": "p_critical", "position": { "x": 740, "y": 120 }, "label": "Critical (Level 1-2)", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
+    { "id": "p_urgent", "position": { "x": 740, "y": 300 }, "label": "Urgent (Level 3)", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
+    { "id": "p_minor", "position": { "x": 740, "y": 480 }, "label": "Minor (Level 4-5)", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
+
+    { "id": "p_lab_ordered", "position": { "x": 920, "y": 120 }, "label": "Labs & Imaging", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
+    { "id": "p_exam_done", "position": { "x": 920, "y": 300 }, "label": "Examined", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
+    { "id": "p_quick_check", "position": { "x": 920, "y": 480 }, "label": "Quick Assessment", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
+
+    { "id": "p_diagnosed", "position": { "x": 1100, "y": 300 }, "label": "Diagnosed", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
+
+    { "id": "p_surgery", "position": { "x": 1280, "y": 160 }, "label": "Surgery / ICU", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
+    { "id": "p_medication", "position": { "x": 1280, "y": 440 }, "label": "Medication Rx", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
+
+    { "id": "p_post_treatment", "position": { "x": 1460, "y": 300 }, "label": "Post-Treatment", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
+
+    { "id": "p_admitted", "position": { "x": 1640, "y": 180 }, "label": "Admitted", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
+    { "id": "p_discharged", "position": { "x": 1640, "y": 420 }, "label": "Discharged", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
+
+    { "id": "p_end", "position": { "x": 1820, "y": 300 }, "label": "Case Closed", "tokens": 0, "capacity": null, "finalMarking": 1, "radius": 20 }
+  ],
+  "transitions": [
+    {
+      "id": "t_register", "position": { "x": 140, "y": 300 },
+      "label": "Register Patient", "width": 20, "height": 50,
+      "isEnabled": true, "priority": 0, "delay": 0,
+      "precondition": "",
+      "postcondition": "patientAge' = Math.floor(Math.random() * 80) + 5; severity' = Math.floor(Math.random() * 5) + 1; heartRate' = Math.floor(Math.random() * 80) + 60; cost' = 150;"
+    },
+    {
+      "id": "t_assess_vitals", "position": { "x": 310, "y": 300 },
+      "label": "Assess Vitals", "width": 20, "height": 50,
+      "isEnabled": false, "priority": 0, "delay": 0,
+      "precondition": "heartRate > 0",
+      "postcondition": "diagnosisCode' = Math.floor(Math.random() * 3);"
+    },
+    {
+      "id": "t_triage", "position": { "x": 490, "y": 300 },
+      "label": "Assign Triage Level", "width": 20, "height": 50,
+      "isEnabled": false, "priority": 0, "delay": 0,
+      "precondition": "severity >= 1 && severity <= 5",
+      "postcondition": ""
+    },
+    {
+      "id": "t_route_critical", "position": { "x": 660, "y": 120 },
+      "label": "Route Critical", "width": 20, "height": 50,
+      "isEnabled": false, "priority": 0, "delay": 0,
+      "precondition": "severity <= 2",
+      "postcondition": "cost' = cost + 5000;"
+    },
+    {
+      "id": "t_route_urgent", "position": { "x": 660, "y": 300 },
+      "label": "Route Urgent", "width": 20, "height": 50,
+      "isEnabled": false, "priority": 0, "delay": 0,
+      "precondition": "severity == 3",
+      "postcondition": "cost' = cost + 2000;"
+    },
+    {
+      "id": "t_route_minor", "position": { "x": 660, "y": 480 },
+      "label": "Route Minor", "width": 20, "height": 50,
+      "isEnabled": false, "priority": 0, "delay": 0,
+      "precondition": "severity >= 4",
+      "postcondition": "cost' = cost + 300;"
+    },
+    {
+      "id": "t_order_labs", "position": { "x": 830, "y": 120 },
+      "label": "Order Labs & Imaging", "width": 20, "height": 50,
+      "isEnabled": false, "priority": 0, "delay": 0,
+      "precondition": "",
+      "postcondition": "cost' = cost + 1200;"
+    },
+    {
+      "id": "t_examine", "position": { "x": 830, "y": 300 },
+      "label": "Physician Exam", "width": 20, "height": 50,
+      "isEnabled": false, "priority": 0, "delay": 0,
+      "precondition": "",
+      "postcondition": "cost' = cost + 600;"
+    },
+    {
+      "id": "t_quick_assess", "position": { "x": 830, "y": 480 },
+      "label": "Nurse Assessment", "width": 20, "height": 50,
+      "isEnabled": false, "priority": 0, "delay": 0,
+      "precondition": "",
+      "postcondition": "cost' = cost + 200;"
+    },
+    {
+      "id": "t_diagnose_critical", "position": { "x": 1010, "y": 120 },
+      "label": "Diagnose (Critical)", "width": 20, "height": 50,
+      "isEnabled": false, "priority": 0, "delay": 0,
+      "precondition": "",
+      "postcondition": ""
+    },
+    {
+      "id": "t_diagnose_urgent", "position": { "x": 1010, "y": 300 },
+      "label": "Diagnose (Urgent)", "width": 20, "height": 50,
+      "isEnabled": false, "priority": 0, "delay": 0,
+      "precondition": "",
+      "postcondition": ""
+    },
+    {
+      "id": "t_diagnose_minor", "position": { "x": 1010, "y": 480 },
+      "label": "Diagnose (Minor)", "width": 20, "height": 50,
+      "isEnabled": false, "priority": 0, "delay": 0,
+      "precondition": "",
+      "postcondition": ""
+    },
+    {
+      "id": "t_treat_surgery", "position": { "x": 1190, "y": 160 },
+      "label": "Surgical Intervention", "width": 20, "height": 50,
+      "isEnabled": false, "priority": 0, "delay": 0,
+      "precondition": "severity <= 2 && diagnosisCode >= 1",
+      "postcondition": "cost' = cost + 15000;"
+    },
+    {
+      "id": "t_treat_medication", "position": { "x": 1190, "y": 440 },
+      "label": "Prescribe Medication", "width": 20, "height": 50,
+      "isEnabled": false, "priority": 0, "delay": 0,
+      "precondition": "diagnosisCode == 0 || severity >= 3",
+      "postcondition": "cost' = cost + 400;"
+    },
+    {
+      "id": "t_post_surgery", "position": { "x": 1370, "y": 160 },
+      "label": "Post-Op Recovery", "width": 20, "height": 50,
+      "isEnabled": false, "priority": 0, "delay": 0,
+      "precondition": "",
+      "postcondition": "cost' = cost + 3000;"
+    },
+    {
+      "id": "t_post_medication", "position": { "x": 1370, "y": 440 },
+      "label": "Monitor Response", "width": 20, "height": 50,
+      "isEnabled": false, "priority": 0, "delay": 0,
+      "precondition": "",
+      "postcondition": ""
+    },
+    {
+      "id": "t_admit", "position": { "x": 1550, "y": 180 },
+      "label": "Admit to Hospital", "width": 20, "height": 50,
+      "isEnabled": false, "priority": 0, "delay": 0,
+      "precondition": "severity <= 2 || (heartRate > 120)",
+      "postcondition": "cost' = cost + 8000;"
+    },
+    {
+      "id": "t_discharge", "position": { "x": 1550, "y": 420 },
+      "label": "Discharge Patient", "width": 20, "height": 50,
+      "isEnabled": false, "priority": 0, "delay": 0,
+      "precondition": "severity >= 3 && heartRate <= 120",
+      "postcondition": ""
+    },
+    {
+      "id": "t_close_admit", "position": { "x": 1730, "y": 180 },
+      "label": "Finalize Admission", "width": 20, "height": 50,
+      "isEnabled": false, "priority": 0, "delay": 0,
+      "precondition": "",
+      "postcondition": ""
+    },
+    {
+      "id": "t_close_discharge", "position": { "x": 1730, "y": 420 },
+      "label": "Finalize Discharge", "width": 20, "height": 50,
+      "isEnabled": false, "priority": 0, "delay": 0,
+      "precondition": "",
+      "postcondition": ""
+    }
+  ],
+  "arcs": [
+    { "id": "a1",  "source": "p_start",      "target": "t_register",        "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a2",  "source": "t_register",    "target": "p_registered",      "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a3",  "source": "p_registered",  "target": "t_assess_vitals",   "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a4",  "source": "t_assess_vitals","target": "p_vitals_taken",   "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a5",  "source": "p_vitals_taken", "target": "t_triage",         "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a6",  "source": "t_triage",       "target": "p_triaged",        "weight": 1, "type": "regular", "points": [], "label": "1" },
+
+    { "id": "a7",  "source": "p_triaged",   "target": "t_route_critical",  "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a8",  "source": "p_triaged",   "target": "t_route_urgent",    "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a9",  "source": "p_triaged",   "target": "t_route_minor",     "weight": 1, "type": "regular", "points": [], "label": "1" },
+
+    { "id": "a10", "source": "t_route_critical", "target": "p_critical",    "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a11", "source": "t_route_urgent",   "target": "p_urgent",      "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a12", "source": "t_route_minor",    "target": "p_minor",       "weight": 1, "type": "regular", "points": [], "label": "1" },
+
+    { "id": "a13", "source": "p_critical", "target": "t_order_labs",     "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a14", "source": "p_urgent",   "target": "t_examine",        "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a15", "source": "p_minor",    "target": "t_quick_assess",   "weight": 1, "type": "regular", "points": [], "label": "1" },
+
+    { "id": "a16", "source": "t_order_labs",   "target": "p_lab_ordered",  "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a17", "source": "t_examine",      "target": "p_exam_done",    "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a18", "source": "t_quick_assess", "target": "p_quick_check",  "weight": 1, "type": "regular", "points": [], "label": "1" },
+
+    { "id": "a19", "source": "p_lab_ordered", "target": "t_diagnose_critical", "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a20", "source": "p_exam_done",   "target": "t_diagnose_urgent",   "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a21", "source": "p_quick_check", "target": "t_diagnose_minor",    "weight": 1, "type": "regular", "points": [], "label": "1" },
+
+    { "id": "a22", "source": "t_diagnose_critical", "target": "p_diagnosed", "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a23", "source": "t_diagnose_urgent",   "target": "p_diagnosed", "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a24", "source": "t_diagnose_minor",    "target": "p_diagnosed", "weight": 1, "type": "regular", "points": [], "label": "1" },
+
+    { "id": "a25", "source": "p_diagnosed", "target": "t_treat_surgery",    "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a26", "source": "p_diagnosed", "target": "t_treat_medication",  "weight": 1, "type": "regular", "points": [], "label": "1" },
+
+    { "id": "a27", "source": "t_treat_surgery",    "target": "p_surgery",    "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a28", "source": "t_treat_medication",  "target": "p_medication", "weight": 1, "type": "regular", "points": [], "label": "1" },
+
+    { "id": "a29", "source": "p_surgery",    "target": "t_post_surgery",    "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a30", "source": "p_medication",  "target": "t_post_medication", "weight": 1, "type": "regular", "points": [], "label": "1" },
+
+    { "id": "a31", "source": "t_post_surgery",    "target": "p_post_treatment", "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a32", "source": "t_post_medication",  "target": "p_post_treatment", "weight": 1, "type": "regular", "points": [], "label": "1" },
+
+    { "id": "a33", "source": "p_post_treatment", "target": "t_admit",     "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a34", "source": "p_post_treatment", "target": "t_discharge",  "weight": 1, "type": "regular", "points": [], "label": "1" },
+
+    { "id": "a35", "source": "t_admit",     "target": "p_admitted",    "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a36", "source": "t_discharge",  "target": "p_discharged", "weight": 1, "type": "regular", "points": [], "label": "1" },
+
+    { "id": "a37", "source": "p_admitted",   "target": "t_close_admit",     "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a38", "source": "p_discharged", "target": "t_close_discharge", "weight": 1, "type": "regular", "points": [], "label": "1" },
+
+    { "id": "a39", "source": "t_close_admit",     "target": "p_end", "weight": 1, "type": "regular", "points": [], "label": "1" },
+    { "id": "a40", "source": "t_close_discharge",  "target": "p_end", "weight": 1, "type": "regular", "points": [], "label": "1" }
+  ],
+  "dataVariables": [
+    { "id": "var_age",       "name": "patientAge",    "type": "number", "currentValue": 0,   "description": "Patient age in years (randomised 5–84 on registration)" },
+    { "id": "var_severity",  "name": "severity",      "type": "number", "currentValue": 0,   "description": "Triage severity level 1 (critical) to 5 (minor)" },
+    { "id": "var_hr",        "name": "heartRate",     "type": "number", "currentValue": 0,   "description": "Heart rate in bpm (randomised 60–139 on registration)" },
+    { "id": "var_diag",      "name": "diagnosisCode", "type": "number", "currentValue": 0,   "description": "Diagnosis code: 0 = manageable, 1 = surgical, 2 = complex" },
+    { "id": "var_cost",      "name": "cost",          "type": "number", "currentValue": 0,   "description": "Cumulative treatment cost in USD" }
+  ]
+}

--- a/public/examples/example-config.json
+++ b/public/examples/example-config.json
@@ -113,6 +113,11 @@
         "name": "DPN: Fibonacci Sequence",
         "description": "Example modeling Fibonacci sequence calculation",
         "path": "public/examples/DPN-Fibonacci(n).json "
+    },
+    {
+        "name": "DPN: Emergency Department Triage & Treatment",
+        "description": "Complex medical workflow with 5 data variables: patient registration, triage by severity, diagnostic workup, treatment branching (surgery vs medication), and admission/discharge decision. Sound workflow net.",
+        "path": "examples/DPN-Emergency-Triage.json"
     }
 
 ]

--- a/src/action-history.js
+++ b/src/action-history.js
@@ -1,0 +1,184 @@
+/**
+ * Action History – Undo / Redo system for YAPNE
+ *
+ * Provides an UndoableAction interface and a central ActionHistory service
+ * that maintains bounded past/future stacks.
+ */
+
+/**
+ * @typedef {Object} UndoableAction
+ * @property {string} label  - Human-readable description (e.g. "Move place P1")
+ * @property {string} icon   - Emoji icon for the action type
+ * @property {number} timestamp - Date.now() when the action was pushed
+ * @property {function} redo - Re-apply the action
+ * @property {function} undo - Reverse the action
+ */
+
+export class ActionHistory {
+  /**
+   * @param {number} [maxSize=50] – Maximum entries kept in the past stack
+   */
+  constructor(maxSize = 50) {
+    /** @type {UndoableAction[]} */
+    this.past = [];
+    /** @type {UndoableAction[]} */
+    this.future = [];
+    this.maxSize = maxSize;
+
+    /**
+     * Index into `past` that represents the last-saved state.
+     * -1 means "saved before any action was pushed".
+     * @type {number}
+     */
+    this._saveIndex = -1;
+
+    /** @type {function|null} */
+    this.onChangeCallback = null;
+  }
+
+  /* ─── public helpers ─── */
+
+  /** Whether the model has unsaved changes */
+  get isDirty() {
+    return this.past.length - 1 !== this._saveIndex;
+  }
+
+  /** Mark the current state as "saved" */
+  markSaved() {
+    this._saveIndex = this.past.length - 1;
+    this._notifyChange();
+  }
+
+  /** Reset everything (e.g. on file load) */
+  clear() {
+    this.past = [];
+    this.future = [];
+    this._saveIndex = -1;
+    this._notifyChange();
+  }
+
+  /* ─── core API ─── */
+
+  /**
+   * Push a new undoable action. Clears the redo stack.
+   * @param {UndoableAction} action
+   */
+  push(action) {
+    this.past.push(action);
+    this.future = [];
+    // Trim if over limit
+    if (this.past.length > this.maxSize) {
+      this.past.shift();
+      // Adjust save index
+      this._saveIndex = Math.max(-1, this._saveIndex - 1);
+    }
+    this._notifyChange();
+  }
+
+  /** Undo the last action. Returns the action or null. */
+  undo() {
+    if (this.past.length === 0) return null;
+    const action = this.past.pop();
+    action.undo();
+    this.future.push(action);
+    this._notifyChange();
+    return action;
+  }
+
+  /** Redo the next action. Returns the action or null. */
+  redo() {
+    if (this.future.length === 0) return null;
+    const action = this.future.pop();
+    action.redo();
+    this.past.push(action);
+    this._notifyChange();
+    return action;
+  }
+
+  /**
+   * Undo everything back to (and including) the entry at `targetIndex`.
+   * All undone entries move to `future`.
+   * @param {number} targetIndex – index in `past` (0-based)
+   */
+  undoTo(targetIndex) {
+    while (this.past.length > targetIndex) {
+      this.undo();
+    }
+  }
+
+  get canUndo() {
+    return this.past.length > 0;
+  }
+
+  get canRedo() {
+    return this.future.length > 0;
+  }
+
+  /** Set a callback that fires whenever history state changes */
+  onChange(cb) {
+    this.onChangeCallback = cb;
+  }
+
+  _notifyChange() {
+    if (this.onChangeCallback) {
+      this.onChangeCallback();
+    }
+  }
+}
+
+/* ─── Action factory helpers ─── */
+
+/**
+ * Icons per action type for the history panel
+ */
+export const ACTION_ICONS = {
+  add: '➕',
+  delete: '🗑️',
+  move: '↔️',
+  edit: '✏️',
+  layout: '🔄',
+  style: '🎨',
+  tokens: '⚫',
+  arc: '→',
+  compound: '📦',
+};
+
+/**
+ * Create a generic undoable action.
+ * @param {string} label
+ * @param {string} icon
+ * @param {function} redoFn
+ * @param {function} undoFn
+ * @returns {UndoableAction}
+ */
+export function createAction(label, icon, redoFn, undoFn) {
+  return {
+    label,
+    icon,
+    timestamp: Date.now(),
+    redo: redoFn,
+    undo: undoFn,
+  };
+}
+
+/**
+ * Wrap multiple actions into a single compound undoable action.
+ * @param {string} label
+ * @param {UndoableAction[]} actions
+ * @returns {UndoableAction}
+ */
+export function compoundAction(label, actions) {
+  return {
+    label,
+    icon: ACTION_ICONS.compound,
+    timestamp: Date.now(),
+    redo() {
+      for (const a of actions) a.redo();
+    },
+    undo() {
+      for (let i = actions.length - 1; i >= 0; i--) actions[i].undo();
+    },
+  };
+}
+
+export default ActionHistory;

--- a/src/auto-save.js
+++ b/src/auto-save.js
@@ -1,0 +1,96 @@
+/**
+ * Auto-Save Manager – periodically saves model to localStorage / IndexedDB
+ * and offers restore on next load.
+ */
+
+const STORAGE_KEY = 'yapne_autosave';
+const STORAGE_TS_KEY = 'yapne_autosave_ts';
+const AUTOSAVE_INTERVAL = 30_000; // 30 seconds
+
+export class AutoSaveManager {
+  /**
+   * @param {function} serialize   – returns the current model JSON string
+   * @param {function} restore     – restores from a JSON string
+   * @param {import('./action-history.js').ActionHistory} actionHistory
+   */
+  constructor(serialize, restore, actionHistory) {
+    this._serialize = serialize;
+    this._restore = restore;
+    this._history = actionHistory;
+    this._intervalId = null;
+  }
+
+  /** Start periodic auto-save */
+  start() {
+    this.stop();
+    this._intervalId = setInterval(() => this._save(), AUTOSAVE_INTERVAL);
+  }
+
+  stop() {
+    if (this._intervalId) {
+      clearInterval(this._intervalId);
+      this._intervalId = null;
+    }
+  }
+
+  _save() {
+    try {
+      if (!this._history.isDirty) return; // nothing new
+      const json = this._serialize();
+      localStorage.setItem(STORAGE_KEY, json);
+      localStorage.setItem(STORAGE_TS_KEY, Date.now().toString());
+    } catch (e) {
+      console.warn('Auto-save failed:', e);
+    }
+  }
+
+  /** Force an immediate save (e.g. before unload) */
+  saveNow() {
+    try {
+      const json = this._serialize();
+      localStorage.setItem(STORAGE_KEY, json);
+      localStorage.setItem(STORAGE_TS_KEY, Date.now().toString());
+    } catch (e) {
+      console.warn('Auto-save failed:', e);
+    }
+  }
+
+  /**
+   * Check whether an auto-saved model exists and offer restore.
+   * @returns {boolean} true if restored
+   */
+  offerRestore() {
+    const json = localStorage.getItem(STORAGE_KEY);
+    const ts = localStorage.getItem(STORAGE_TS_KEY);
+    if (!json || !ts) return false;
+
+    const date = new Date(parseInt(ts, 10));
+    const timeStr = date.toLocaleString();
+
+    const doRestore = confirm(
+      `An auto-saved model was found from ${timeStr}.\n\nWould you like to restore it?`
+    );
+
+    if (doRestore) {
+      try {
+        this._restore(json);
+        return true;
+      } catch (e) {
+        console.error('Auto-restore failed:', e);
+        alert('Could not restore the auto-saved model.');
+      }
+    }
+
+    // Clear stale auto-save
+    this.clearSaved();
+    return false;
+  }
+
+  /** Remove auto-save data */
+  clearSaved() {
+    localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem(STORAGE_TS_KEY);
+  }
+}
+
+export default AutoSaveManager;

--- a/src/history-dialog.js
+++ b/src/history-dialog.js
@@ -1,0 +1,254 @@
+/**
+ * History Dialog – side-panel listing past undoable actions
+ */
+import { ActionHistory } from './action-history.js';
+
+export class HistoryDialog {
+  /**
+   * @param {ActionHistory} actionHistory
+   * @param {function} onHistoryNav – called after any undo/redo so the app can re-render
+   */
+  constructor(actionHistory, onHistoryNav) {
+    this.history = actionHistory;
+    this.onHistoryNav = onHistoryNav;
+    this._panel = null;
+    this._listEl = null;
+    this._visible = false;
+  }
+
+  /** Create DOM (called once). Appends a fixed side-panel to the body. */
+  init() {
+    if (this._panel) return;
+
+    // Inject styles
+    const style = document.createElement('style');
+    style.textContent = `
+      .history-panel {
+        position: fixed;
+        top: 0;
+        right: -340px;
+        width: 320px;
+        height: 100vh;
+        background: #3B4252;
+        border-left: 2px solid #4C566A;
+        z-index: 9000;
+        display: flex;
+        flex-direction: column;
+        transition: right 0.25s ease;
+        box-shadow: -4px 0 16px rgba(0,0,0,0.4);
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      }
+      .history-panel.open { right: 0; }
+      .history-panel-header {
+        background: #434C5E;
+        padding: 14px 16px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        border-bottom: 1px solid #4C566A;
+      }
+      .history-panel-header h3 {
+        margin: 0;
+        color: #ECEFF4;
+        font-size: 15px;
+      }
+      .history-panel-close {
+        background: none;
+        border: none;
+        color: #D8DEE9;
+        font-size: 20px;
+        cursor: pointer;
+        border-radius: 4px;
+        width: 28px;
+        height: 28px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .history-panel-close:hover { background: #4C566A; }
+      .history-panel-actions {
+        display: flex;
+        gap: 6px;
+        padding: 10px 16px;
+        border-bottom: 1px solid #4C566A;
+      }
+      .history-panel-actions button {
+        flex: 1;
+        padding: 6px 0;
+        border: 1px solid #4C566A;
+        background: #434C5E;
+        color: #D8DEE9;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 13px;
+      }
+      .history-panel-actions button:disabled {
+        opacity: 0.4;
+        cursor: default;
+      }
+      .history-panel-actions button:not(:disabled):hover {
+        background: #4C566A;
+      }
+      .history-list {
+        flex: 1;
+        overflow-y: auto;
+        padding: 8px;
+      }
+      .history-list::-webkit-scrollbar { width: 6px; }
+      .history-list::-webkit-scrollbar-thumb { background: #4C566A; border-radius: 3px; }
+      .history-item {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 8px 10px;
+        border-radius: 6px;
+        cursor: pointer;
+        margin-bottom: 2px;
+        transition: background 0.15s;
+      }
+      .history-item:hover { background: rgba(136,192,208,0.12); }
+      .history-item-icon { font-size: 16px; flex-shrink: 0; }
+      .history-item-label {
+        flex: 1;
+        color: #D8DEE9;
+        font-size: 13px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .history-item-time {
+        color: #81A1C1;
+        font-size: 11px;
+        flex-shrink: 0;
+      }
+      .history-item.future-item { opacity: 0.45; }
+      .history-empty {
+        text-align: center;
+        color: #81A1C1;
+        padding: 40px 16px;
+        font-size: 13px;
+        font-style: italic;
+      }
+      .history-separator {
+        text-align: center;
+        color: #5E81AC;
+        font-size: 11px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 1px;
+        padding: 6px 0;
+        border-bottom: 1px solid #4C566A;
+        margin: 4px 0;
+      }
+    `;
+    document.head.appendChild(style);
+
+    // Build DOM
+    this._panel = document.createElement('div');
+    this._panel.className = 'history-panel';
+    this._panel.innerHTML = `
+      <div class="history-panel-header">
+        <h3>📜 Action History</h3>
+        <button class="history-panel-close" title="Close">×</button>
+      </div>
+      <div class="history-panel-actions">
+        <button id="hist-undo-btn">↩ Undo</button>
+        <button id="hist-redo-btn">↪ Redo</button>
+      </div>
+      <div class="history-list"></div>
+    `;
+    document.body.appendChild(this._panel);
+
+    this._listEl = this._panel.querySelector('.history-list');
+
+    // Events
+    this._panel.querySelector('.history-panel-close').addEventListener('click', () => this.toggle());
+    this._panel.querySelector('#hist-undo-btn').addEventListener('click', () => {
+      this.history.undo();
+      this.onHistoryNav();
+      this.refresh();
+    });
+    this._panel.querySelector('#hist-redo-btn').addEventListener('click', () => {
+      this.history.redo();
+      this.onHistoryNav();
+      this.refresh();
+    });
+
+    // Refresh when history changes
+    this.history.onChange(() => this.refresh());
+  }
+
+  toggle() {
+    this._visible = !this._visible;
+    this._panel.classList.toggle('open', this._visible);
+    if (this._visible) this.refresh();
+  }
+
+  refresh() {
+    if (!this._listEl) return;
+
+    const undoBtn = this._panel.querySelector('#hist-undo-btn');
+    const redoBtn = this._panel.querySelector('#hist-redo-btn');
+    undoBtn.disabled = !this.history.canUndo;
+    redoBtn.disabled = !this.history.canRedo;
+
+    let html = '';
+
+    if (this.history.past.length === 0 && this.history.future.length === 0) {
+      html = '<div class="history-empty">No actions recorded yet.<br>Start editing to see history.</div>';
+      this._listEl.innerHTML = html;
+      return;
+    }
+
+    // Future items (redo stack, shown at the top, greyed out, oldest first)
+    if (this.history.future.length > 0) {
+      html += '<div class="history-separator">— Redo —</div>';
+      // Future: bottom of stack is oldest = first to redo
+      for (let i = 0; i < this.history.future.length; i++) {
+        const action = this.history.future[i];
+        html += this._renderItem(action, -1, true);
+      }
+    }
+
+    // Current state marker
+    html += '<div class="history-separator">— Now —</div>';
+
+    // Past items (most recent first)
+    for (let i = this.history.past.length - 1; i >= 0; i--) {
+      const action = this.history.past[i];
+      html += this._renderItem(action, i, false);
+    }
+
+    this._listEl.innerHTML = html;
+
+    // Click handlers on past items
+    this._listEl.querySelectorAll('.history-item[data-idx]').forEach(el => {
+      el.addEventListener('click', () => {
+        const idx = parseInt(el.dataset.idx, 10);
+        if (idx >= 0) {
+          this.history.undoTo(idx);
+          this.onHistoryNav();
+          this.refresh();
+        }
+      });
+    });
+  }
+
+  _renderItem(action, index, isFuture) {
+    const cls = isFuture ? 'history-item future-item' : 'history-item';
+    const timeStr = this._formatTime(action.timestamp);
+    const dataAttr = index >= 0 ? `data-idx="${index}"` : '';
+    return `<div class="${cls}" ${dataAttr} title="${isFuture ? 'Future (redo)' : 'Click to undo to this point'}">
+      <span class="history-item-icon">${action.icon || '•'}</span>
+      <span class="history-item-label">${action.label}</span>
+      <span class="history-item-time">${timeStr}</span>
+    </div>`;
+  }
+
+  _formatTime(ts) {
+    const d = new Date(ts);
+    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+  }
+}
+
+export default HistoryDialog;

--- a/src/petri-net-app.js
+++ b/src/petri-net-app.js
@@ -4,7 +4,9 @@
  * This file contains the implementation of a web application that uses the Petri Net Editor library.
  * It demonstrates how to create, edit, simulate, and analyze Petri nets.
  */
-import { PetriNetAPI } from './petri-net-simulator.js';
+import { PetriNetAPI, Place, Transition, Arc } from './petri-net-simulator.js';
+import HistoryDialog from './history-dialog.js';
+import { ActionHistory, createAction, ACTION_ICONS } from './action-history.js';
 
 class PetriNetApp {
   /**
@@ -54,7 +56,21 @@ class PetriNetApp {
     this.api = new PetriNetAPI();
     this.editor = this.api.attachEditor(this.canvas);
     
-    
+    // ── Snapshot-based undo/redo system ──
+    this._undoStack = [];      // past snapshots (JSON strings)
+    this._redoStack = [];      // future snapshots
+    this._maxSnapshots = 80;   // limit memory usage
+    this._isRestoring = false; // guard: don't snapshot during undo/redo
+
+    // ActionHistory instance is kept for the HistoryDialog UI
+    this.actionHistory = new ActionHistory(100);
+    this.historyDialog = new HistoryDialog(this.actionHistory, () => {
+      this.editor.render();
+      this.updateTokensDisplay();
+      this.updateSelectedElementProperties();
+      this.updateUndoRedoButtons();
+    });
+    this.historyDialog.init();
 
     this.api.setZoomSensitivity(0.05);
 
@@ -71,6 +87,9 @@ class PetriNetApp {
 
     // Add initial place to the editor
     this.addInitialPlace();
+
+    // Take the very first snapshot (initial state)
+    this._takeSnapshot('Initial state');
 
     this.editor.render();
     this.updateTokensDisplay();
@@ -228,8 +247,47 @@ initEventHandlers() {
     this.appEventListeners.push(['click', handler, btnAddArc]);
   }
 
+  // Undo / Redo / History buttons
+  const btnUndo = document.getElementById("btn-undo");
+  if (btnUndo) {
+    const handler = () => this.performUndo();
+    btnUndo.addEventListener("click", handler);
+    this.appEventListeners.push(['click', handler, btnUndo]);
+  }
+
+  const btnRedo = document.getElementById("btn-redo");
+  if (btnRedo) {
+    const handler = () => this.performRedo();
+    btnRedo.addEventListener("click", handler);
+    this.appEventListeners.push(['click', handler, btnRedo]);
+  }
+
+  const btnHistory = document.getElementById("btn-history");
+  if (btnHistory) {
+    const handler = () => this.historyDialog.toggle();
+    btnHistory.addEventListener("click", handler);
+    this.appEventListeners.push(['click', handler, btnHistory]);
+  }
+
   // Space key handlers for arc mode
   const keydownHandler = (e) => {
+    // Don't intercept undo/redo when a text input is focused
+    const tag = document.activeElement?.tagName;
+    const isInputFocused = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+
+    // Undo: Ctrl+Z / Cmd+Z
+    if (e.key === 'z' && (e.ctrlKey || e.metaKey) && !e.shiftKey && !isInputFocused) {
+      e.preventDefault();
+      this.performUndo();
+      return;
+    }
+    // Redo: Ctrl+Shift+Z / Cmd+Shift+Z  or  Ctrl+Y / Cmd+Y
+    if (((e.key === 'z' && (e.ctrlKey || e.metaKey) && e.shiftKey) ||
+        (e.key === 'y' && (e.ctrlKey || e.metaKey))) && !isInputFocused) {
+      e.preventDefault();
+      this.performRedo();
+      return;
+    }
     if (e.key === ' ' && this.editor && this.editor.mode !== 'addArc') {
       e.preventDefault();
       e.stopPropagation();
@@ -538,6 +596,7 @@ initEventHandlers() {
     if (labelInput) {
       labelInput.addEventListener("change", (e) => {
         this.api.setLabel(id, e.target.value);
+        this._takeSnapshot(`Rename place to ${e.target.value}`);
       });
     }
 
@@ -550,6 +609,7 @@ initEventHandlers() {
           this.updateTokensDisplay();
           this.updateFinalMarkingDisplay(); 
           this.editor.render();
+          this._takeSnapshot(`Set tokens ${place.label} to ${value}`);
         }
       });
     }
@@ -561,6 +621,7 @@ initEventHandlers() {
         if (!isNaN(value)) {
           place.capacity = value === 0 ? null : value;
           this.editor.render();
+          this._takeSnapshot('Change capacity');
         }
       });
     }
@@ -579,6 +640,7 @@ initEventHandlers() {
         }
         this.editor.render();
         this.updateFinalMarkingDisplay();
+        this._takeSnapshot('Change final marking');
         this.showPlaceProperties(id);
       });
     }
@@ -655,6 +717,7 @@ initEventHandlers() {
         // Re-render the properties panel to update disabled state
         this.showTransitionProperties(id);
         this.editor.render();
+        this._takeSnapshot(e.target.checked ? 'Make silent' : 'Make visible');
       });
     }
 
@@ -662,6 +725,7 @@ initEventHandlers() {
     if (labelInput) {
       labelInput.addEventListener("change", (e) => {
         this.api.setLabel(id, e.target.value);
+        this._takeSnapshot(`Rename transition to ${e.target.value}`);
       });
     }
 
@@ -672,6 +736,7 @@ initEventHandlers() {
         if (!isNaN(value) && value >= 1) {
           transition.priority = value;
           this.editor.render();
+          this._takeSnapshot('Change priority');
         }
       });
     }
@@ -683,6 +748,7 @@ initEventHandlers() {
         if (!isNaN(value) && value >= 0) {
           transition.delay = value;
           this.editor.render();
+          this._takeSnapshot('Change delay');
         }
       });
     }
@@ -828,6 +894,7 @@ initEventHandlers() {
           if (labelInput && !labelInput.value) {
             arc.label = value.toString();
           }
+          this._takeSnapshot('Change arc weight');
         }
       });
     }
@@ -836,6 +903,7 @@ initEventHandlers() {
     if (typeSelect) {
       typeSelect.addEventListener("change", (e) => {
         this.api.setArcType(id, e.target.value);
+        this._takeSnapshot('Change arc type');
       });
     }
 
@@ -845,6 +913,7 @@ initEventHandlers() {
         const label = e.target.value || arc.weight.toString();
         arc.label = label;
         this.editor.render();
+        this._takeSnapshot('Change arc label');
       });
     }
   }
@@ -908,12 +977,165 @@ initEventHandlers() {
     this.updateTokensDisplay();
     this.updateFinalMarkingDisplay();
 
+    // Record a snapshot for undo on every change (unless we're mid-restore)
+    if (!this._isRestoring) {
+      this._takeSnapshot('Edit');
+    }
+
     if (this.editor.selectedElement) {
       this.handleElementSelected(
         this.editor.selectedElement.id,
         this.editor.selectedElement.type
       );
     }
+  }
+
+  /* ═══════════════════════════════════════════════
+   *  Snapshot-based Undo / Redo
+   * ═══════════════════════════════════════════════ */
+
+  /**
+   * Serialize the current PetriNet state and push it onto the undo stack.
+   * Clears the redo stack (new edit branch).
+   * Skips if the state hasn't actually changed since the last snapshot.
+   */
+  _takeSnapshot(label = 'Edit') {
+    const json = this.api.petriNet.toJSON();
+    // Deduplicate: skip if the state is identical to the top of the stack
+    if (this._undoStack.length > 0 &&
+        this._undoStack[this._undoStack.length - 1].json === json) {
+      return;
+    }
+    this._undoStack.push({ json, label, timestamp: Date.now() });
+    this._redoStack = [];
+    // Trim oldest entries if over limit
+    while (this._undoStack.length > this._maxSnapshots) {
+      this._undoStack.shift();
+    }
+    // Sync the ActionHistory so the dialog stays up-to-date
+    this._syncActionHistory();
+    this.updateUndoRedoButtons();
+  }
+
+  /**
+   * Restore a JSON snapshot into the current PetriNet **in-place**
+   * (without recreating the editor).
+   */
+  _restoreSnapshot(json) {
+    this._isRestoring = true;
+    try {
+      const data = JSON.parse(json);
+      const net = this.api.petriNet;
+
+      // 1. Clear current data
+      net.places.clear();
+      net.transitions.clear();
+      net.arcs.clear();
+
+      // 2. Restore net-level metadata
+      if (data.id) net.id = data.id;
+      if (data.name !== undefined) net.name = data.name;
+      if (data.description !== undefined) net.description = data.description;
+
+      // 3. Rebuild from snapshot using the imported classes directly
+      if (data.places) {
+        for (const pd of data.places) {
+          const place = new Place(pd.id, pd.position, pd.label, pd.tokens, pd.capacity, pd.finalMarking);
+          net.places.set(place.id, place);
+        }
+      }
+      if (data.transitions) {
+        for (const td of data.transitions) {
+          const isSilent = td.silent || !td.label || td.label.trim() === '';
+          const tr = new Transition(td.id, td.position, td.label || '', td.priority, td.delay, isSilent);
+          net.transitions.set(tr.id, tr);
+        }
+      }
+      if (data.arcs) {
+        for (const ad of data.arcs) {
+          const arc = new Arc(ad.id, ad.source, ad.target, ad.weight, ad.type, ad.points || [], ad.label);
+          net.arcs.set(arc.id, arc);
+        }
+      }
+
+      // 4. Refresh everything
+      this.editor.selectedElement = null;
+      this.editor.render();
+      this.updateTokensDisplay();
+      this.updateFinalMarkingDisplay();
+      this.propertiesPanel.innerHTML = '<p>No element selected.</p>';
+    } finally {
+      this._isRestoring = false;
+    }
+  }
+
+  /** Execute undo */
+  performUndo() {
+    // We need at least 2 entries: [previous_state, current_state]
+    if (this._undoStack.length < 2) return;
+    // Move current state to redo
+    const current = this._undoStack.pop();
+    this._redoStack.push(current);
+    // Restore the previous state
+    const prev = this._undoStack[this._undoStack.length - 1];
+    this._restoreSnapshot(prev.json);
+    this._syncActionHistory();
+    this.updateUndoRedoButtons();
+  }
+
+  /** Execute redo */
+  performRedo() {
+    if (this._redoStack.length === 0) return;
+    const next = this._redoStack.pop();
+    this._undoStack.push(next);
+    this._restoreSnapshot(next.json);
+    this._syncActionHistory();
+    this.updateUndoRedoButtons();
+  }
+
+  /** Sync the ActionHistory entries so the HistoryDialog panel can display them. */
+  _syncActionHistory() {
+    this.actionHistory.past = [];
+    this.actionHistory.future = [];
+    // past = undoStack entries (skip index 0 which is the baseline)
+    for (let i = 1; i < this._undoStack.length; i++) {
+      const s = this._undoStack[i];
+      this.actionHistory.past.push({
+        label: s.label,
+        icon: ACTION_ICONS.edit,
+        timestamp: s.timestamp,
+        redo() {},
+        undo() {},
+      });
+    }
+    // future = redoStack (reversed, oldest first)
+    for (let i = this._redoStack.length - 1; i >= 0; i--) {
+      const s = this._redoStack[i];
+      this.actionHistory.future.push({
+        label: s.label,
+        icon: ACTION_ICONS.edit,
+        timestamp: s.timestamp,
+        redo() {},
+        undo() {},
+      });
+    }
+    this.actionHistory._notifyChange();
+  }
+
+  /** Sync the disabled state of the toolbar undo/redo buttons */
+  updateUndoRedoButtons() {
+    const btnUndo = document.getElementById("btn-undo");
+    const btnRedo = document.getElementById("btn-redo");
+    if (btnUndo) btnUndo.disabled = this._undoStack.length < 2;
+    if (btnRedo) btnRedo.disabled = this._redoStack.length === 0;
+  }
+
+  /** Reset the undo/redo stacks (called on file load / reset) */
+  _resetUndoHistory() {
+    this._undoStack = [];
+    this._redoStack = [];
+    this.actionHistory.clear();
+    this._takeSnapshot('Initial state');
   }
 
   /**
@@ -1084,6 +1306,9 @@ initEventHandlers() {
     this.editor.setMode("select");
     this.updateActiveButton("btn-select");
 
+    // Reset undo/redo stacks for the new editor
+    this._resetUndoHistory();
+
     this.editor.render();
     this.updateTokensDisplay();
     this.updateZoomDisplay();
@@ -1217,6 +1442,9 @@ initEventHandlers() {
           this.editor.setMode("select");
           this.updateActiveButton("btn-select");
 
+          // Reset undo/redo stacks for the new editor
+          this._resetUndoHistory();
+
           this.editor.render();
           this.updateTokensDisplay();
           this.updateZoomDisplay();
@@ -1347,6 +1575,9 @@ initEventHandlers() {
           
           // Reinitialize all handlers
           this.initEventHandlers();
+
+          // Reset undo/redo stacks for the new editor
+          this._resetUndoHistory();
 
           // Reset all simulation and UI state
           this.initialState = null;

--- a/src/petri-net-simulator.js
+++ b/src/petri-net-simulator.js
@@ -1444,23 +1444,9 @@ class PetriNetEditor {
 
 
     const keyDownHandler = (event) => {
-      // Delete currently selected element
+      // Delete currently selected element – delegate to deleteSelected()
       if (event.code === 'Delete' && this.selectedElement) {
-        if (this.selectedElement.type === 'place') {
-          this.petriNet.removePlace(this.selectedElement.id);
-        } else if (this.selectedElement.type === 'transition') {
-          this.petriNet.removeTransition(this.selectedElement.id);
-        } else if (this.selectedElement.type === 'arc') {
-          this.petriNet.removeArc(this.selectedElement.id);
-        } 
-
-
-        this.selectedElement = null;
-        this.dragOffset = null;
-        if (this.callbacks.onChange) {
-          this.callbacks.onChange();
-        }
-        this.render();
+        this.deleteSelected();
         return;
       }
 

--- a/styles/features.css
+++ b/styles/features.css
@@ -1,0 +1,177 @@
+/* ===== YAPNE Feature Extensions Styles ===== */
+
+/* ─── Undo/Redo toolbar ─── */
+.undo-redo-controls {
+  display: flex;
+  gap: 2px;
+  align-items: center;
+}
+
+.undo-redo-controls button {
+  background: rgba(67, 76, 94, 0.9);
+  border: 1px solid #4C566A;
+  color: #D8DEE9;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background 0.15s;
+}
+
+.undo-redo-controls button:hover:not(:disabled) {
+  background: #4C566A;
+}
+
+.undo-redo-controls button:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+/* ─── Node / Arc Styling panel ─── */
+.style-section {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid #4C566A;
+}
+
+.style-section h4 {
+  margin: 0 0 10px 0;
+  font-size: 13px;
+  color: #88C0D0;
+}
+
+.style-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.style-row label {
+  flex: 0 0 90px;
+  font-size: 12px;
+  color: #D8DEE9;
+}
+
+.style-row input[type="color"] {
+  width: 32px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid #4C566A;
+  border-radius: 4px;
+  background: none;
+  cursor: pointer;
+}
+
+.style-row input[type="range"] {
+  flex: 1;
+  accent-color: #88C0D0;
+}
+
+.style-row select {
+  flex: 1;
+  padding: 3px 6px;
+  background: #3B4252;
+  color: #D8DEE9;
+  border: 1px solid #4C566A;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.style-row .range-value {
+  flex: 0 0 30px;
+  text-align: right;
+  font-size: 11px;
+  color: #81A1C1;
+}
+
+/* ─── Simulation mode styling ─── */
+.sim-mode-toggle {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 10px;
+  background: #3B4252;
+  border-radius: 6px;
+  padding: 3px;
+}
+
+.sim-mode-toggle button {
+  flex: 1;
+  padding: 6px 10px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: #D8DEE9;
+  cursor: pointer;
+  font-size: 12px;
+  transition: all 0.15s;
+}
+
+.sim-mode-toggle button.active {
+  background: #5E81AC;
+  color: #ECEFF4;
+}
+
+.sim-mode-toggle button:hover:not(.active) {
+  background: rgba(136, 192, 208, 0.15);
+}
+
+/* ─── Simulation trace log ─── */
+.sim-trace-log {
+  max-height: 200px;
+  overflow-y: auto;
+  background: rgba(46, 52, 64, 0.5);
+  border-radius: 6px;
+  padding: 8px;
+  margin-top: 8px;
+}
+
+.sim-trace-log::-webkit-scrollbar {
+  width: 5px;
+}
+
+.sim-trace-log::-webkit-scrollbar-thumb {
+  background: #4C566A;
+  border-radius: 3px;
+}
+
+.sim-trace-entry {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  font-size: 12px;
+  color: #D8DEE9;
+  margin-bottom: 2px;
+}
+
+.sim-trace-entry:hover {
+  background: rgba(136, 192, 208, 0.1);
+}
+
+.sim-trace-step-num {
+  background: #5E81AC;
+  color: #ECEFF4;
+  padding: 1px 6px;
+  border-radius: 10px;
+  font-size: 10px;
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.sim-trace-transitions {
+  flex: 1;
+  color: #88C0D0;
+}
+
+/* ─── Enabled transition highlight (canvas CSS fallback) ─── */
+@keyframes enabledPulse {
+  0%, 100% { box-shadow: 0 0 6px rgba(163, 190, 140, 0.4); }
+  50% { box-shadow: 0 0 14px rgba(163, 190, 140, 0.8); }
+}
+
+/* ─── Verification tab ─── */
+.verification-pane .sidebar-section {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
Introduce a snapshot-based undo/redo system, an ActionHistory service and a HistoryDialog side-panel to inspect and navigate past/future edits. Add AutoSaveManager to periodically persist the model to localStorage and offer restore on load. Wire up toolbar buttons and keyboard shortcuts (Ctrl/Cmd+Z, Ctrl/Cmd+Shift+Z / Y), sync snapshots with the history UI, and expose undo/redo controls in the toolbar. Small refactor to delegate delete handling to deleteSelected(), add feature styles, and register a new example (DPN-Emergency-Triage) in example-config.json.