### PR TITLE
Add Python importer and guard-language support

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 import { DataPetriNetIntegration } from "./src/extensions/dpn-integration.js";
 import { initializeProbabilisticExecution } from "./src/extensions/probabilistic-integration.js";
 import { initWorkflowTutorial } from "./src/workflow-tutorial.js";
+import { PythonImportDialog } from "./src/extensions/python-import-dialog.js";
 
 const BASE_PATH = '/YAPNE-Yet-Another-Petri-Net-Editor/';
 
@@ -305,6 +306,15 @@ document.addEventListener('DOMContentLoaded', () => {
         const initTimer = setInterval(() => {
             if (window.petriApp) {
                 window.dataPetriNetIntegration = new DataPetriNetIntegration(window.petriApp);
+
+                // Python Import Dialog
+                const btnImportPython = document.getElementById('btn-import-python');
+                if (btnImportPython) {
+                    btnImportPython.addEventListener('click', () => {
+                        const dialog = new PythonImportDialog(window.petriApp);
+                        dialog.open();
+                    });
+                }
                 
                 // Initialize Probabilistic Execution Integration
                 // Implements "Data Petri Nets Meet Probabilistic Programming" (Kuhn et al., BPM 2024)

--- a/docs/architecture.drawio
+++ b/docs/architecture.drawio
@@ -1,6 +1,6 @@
 <mxfile host="65bd71144e">
     <diagram id="vSwrTl0TiaWD3OvGHumz" name="webppl">
-        <mxGraphModel dx="892" dy="518" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+        <mxGraphModel dx="1400" dy="1103" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
@@ -240,7 +240,7 @@
         </mxGraphModel>
     </diagram>
     <diagram id="gJyLSrSMGuZ0JyBximxG" name="architecture">
-        <mxGraphModel dx="892" dy="518" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+        <mxGraphModel dx="1050" dy="827" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     <link rel="stylesheet" href="styles/features.css">
     <link rel="stylesheet" href="styles/side-panels.css">
     <link rel="stylesheet" href="styles/workflow-tutorial.css">
+    <link rel="stylesheet" href="styles/python-importer.css">
 
     <!-- 
       WebPPL Bundle for Probabilistic Programming
@@ -457,6 +458,9 @@
                                 </div>
                                 <div class="button-group" id="pnml-button-group">
                                     <button id="btn-export-pnml" style="background-color: rgb(101, 127, 152);">Save (PNML)</button>
+                                </div>
+                                <div class="button-group">
+                                    <button id="btn-import-python">🐍 Import Python (⚠️ BETA)</button>
                                 </div>
                             </div>
                         </div>

--- a/public/examples/DPN-Emergency-Triage.json
+++ b/public/examples/DPN-Emergency-Triage.json
@@ -3,234 +3,910 @@
   "name": "Emergency Department Triage & Treatment",
   "description": "A data Petri net modelling an emergency department workflow: patient arrives, vitals are assessed, a triage level is assigned based on severity, diagnostic tests are ordered, treatment is chosen based on diagnosis, and the patient is either discharged or admitted to the hospital. Uses 5 data variables with guard-based branching.",
   "places": [
-    { "id": "p_start", "position": { "x": 60, "y": 300 }, "label": "Patient Arrival", "tokens": 1, "capacity": null, "finalMarking": 0, "radius": 20 },
-    { "id": "p_registered", "position": { "x": 220, "y": 300 }, "label": "Registered", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
-    { "id": "p_vitals_taken", "position": { "x": 400, "y": 300 }, "label": "Vitals Assessed", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
-    { "id": "p_triaged", "position": { "x": 580, "y": 300 }, "label": "Triaged", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
-
-    { "id": "p_critical", "position": { "x": 740, "y": 120 }, "label": "Critical (Level 1-2)", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
-    { "id": "p_urgent", "position": { "x": 740, "y": 300 }, "label": "Urgent (Level 3)", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
-    { "id": "p_minor", "position": { "x": 740, "y": 480 }, "label": "Minor (Level 4-5)", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
-
-    { "id": "p_lab_ordered", "position": { "x": 920, "y": 120 }, "label": "Labs & Imaging", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
-    { "id": "p_exam_done", "position": { "x": 920, "y": 300 }, "label": "Examined", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
-    { "id": "p_quick_check", "position": { "x": 920, "y": 480 }, "label": "Quick Assessment", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
-
-    { "id": "p_diagnosed", "position": { "x": 1100, "y": 300 }, "label": "Diagnosed", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
-
-    { "id": "p_surgery", "position": { "x": 1280, "y": 160 }, "label": "Surgery / ICU", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
-    { "id": "p_medication", "position": { "x": 1280, "y": 440 }, "label": "Medication Rx", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
-
-    { "id": "p_post_treatment", "position": { "x": 1460, "y": 300 }, "label": "Post-Treatment", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
-
-    { "id": "p_admitted", "position": { "x": 1640, "y": 180 }, "label": "Admitted", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
-    { "id": "p_discharged", "position": { "x": 1640, "y": 420 }, "label": "Discharged", "tokens": 0, "capacity": null, "finalMarking": 0, "radius": 20 },
-
-    { "id": "p_end", "position": { "x": 1820, "y": 300 }, "label": "Case Closed", "tokens": 0, "capacity": null, "finalMarking": 1, "radius": 20 }
+    {
+      "id": "p_start",
+      "position": {
+        "x": 60,
+        "y": 300
+      },
+      "label": "Patient Arrival",
+      "tokens": 1,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_registered",
+      "position": {
+        "x": 220,
+        "y": 300
+      },
+      "label": "Registered",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_vitals_taken",
+      "position": {
+        "x": 400,
+        "y": 300
+      },
+      "label": "Vitals Assessed",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_triaged",
+      "position": {
+        "x": 580,
+        "y": 300
+      },
+      "label": "Triaged",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_critical",
+      "position": {
+        "x": 740,
+        "y": 120
+      },
+      "label": "Critical (Level 1-2)",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_urgent",
+      "position": {
+        "x": 740,
+        "y": 300
+      },
+      "label": "Urgent (Level 3)",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_minor",
+      "position": {
+        "x": 740,
+        "y": 480
+      },
+      "label": "Minor (Level 4-5)",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_lab_ordered",
+      "position": {
+        "x": 920,
+        "y": 120
+      },
+      "label": "Labs & Imaging",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_exam_done",
+      "position": {
+        "x": 920,
+        "y": 300
+      },
+      "label": "Examined",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_quick_check",
+      "position": {
+        "x": 920,
+        "y": 480
+      },
+      "label": "Quick Assessment",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_diagnosed",
+      "position": {
+        "x": 1100,
+        "y": 300
+      },
+      "label": "Diagnosed",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_surgery",
+      "position": {
+        "x": 1280,
+        "y": 160
+      },
+      "label": "Surgery / ICU",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_medication",
+      "position": {
+        "x": 1280,
+        "y": 440
+      },
+      "label": "Medication Rx",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_post_treatment",
+      "position": {
+        "x": 1460,
+        "y": 300
+      },
+      "label": "Post-Treatment",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_admitted",
+      "position": {
+        "x": 1640,
+        "y": 180
+      },
+      "label": "Admitted",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_discharged",
+      "position": {
+        "x": 1640,
+        "y": 420
+      },
+      "label": "Discharged",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_end",
+      "position": {
+        "x": 1820,
+        "y": 300
+      },
+      "label": "Case Closed",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 1,
+      "radius": 20
+    }
   ],
   "transitions": [
     {
-      "id": "t_register", "position": { "x": 140, "y": 300 },
-      "label": "Register Patient", "width": 20, "height": 50,
-      "isEnabled": true, "priority": 0, "delay": 0,
+      "id": "t_register",
+      "position": {
+        "x": 140,
+        "y": 300
+      },
+      "label": "Register Patient",
+      "width": 20,
+      "height": 50,
+      "isEnabled": true,
+      "priority": 0,
+      "delay": 0,
       "precondition": "",
-      "postcondition": "patientAge' = Math.floor(Math.random() * 80) + 5; severity' = Math.floor(Math.random() * 5) + 1; heartRate' = Math.floor(Math.random() * 80) + 60; cost' = 150;"
+      "postcondition": "patientAge' >= 5 and patientAge' <= 85 and severity' >= 1 and severity' <= 5 and heartRate' >= 60 and heartRate' <= 140 and cost' = 150"
     },
     {
-      "id": "t_assess_vitals", "position": { "x": 310, "y": 300 },
-      "label": "Assess Vitals", "width": 20, "height": 50,
-      "isEnabled": false, "priority": 0, "delay": 0,
+      "id": "t_assess_vitals",
+      "position": {
+        "x": 310,
+        "y": 300
+      },
+      "label": "Assess Vitals",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
       "precondition": "heartRate > 0",
-      "postcondition": "diagnosisCode' = Math.floor(Math.random() * 3);"
+      "postcondition": "diagnosisCode' >= 0 and diagnosisCode' <= 2"
     },
     {
-      "id": "t_triage", "position": { "x": 490, "y": 300 },
-      "label": "Assign Triage Level", "width": 20, "height": 50,
-      "isEnabled": false, "priority": 0, "delay": 0,
-      "precondition": "severity >= 1 && severity <= 5",
+      "id": "t_triage",
+      "position": {
+        "x": 490,
+        "y": 300
+      },
+      "label": "Assign Triage Level",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "severity >= 1 and severity <= 5",
       "postcondition": ""
     },
     {
-      "id": "t_route_critical", "position": { "x": 660, "y": 120 },
-      "label": "Route Critical", "width": 20, "height": 50,
-      "isEnabled": false, "priority": 0, "delay": 0,
+      "id": "t_route_critical",
+      "position": {
+        "x": 660,
+        "y": 120
+      },
+      "label": "Route Critical",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
       "precondition": "severity <= 2",
-      "postcondition": "cost' = cost + 5000;"
+      "postcondition": "cost' = cost + 5000"
     },
     {
-      "id": "t_route_urgent", "position": { "x": 660, "y": 300 },
-      "label": "Route Urgent", "width": 20, "height": 50,
-      "isEnabled": false, "priority": 0, "delay": 0,
-      "precondition": "severity == 3",
-      "postcondition": "cost' = cost + 2000;"
+      "id": "t_route_urgent",
+      "position": {
+        "x": 660,
+        "y": 300
+      },
+      "label": "Route Urgent",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "severity = 3",
+      "postcondition": "cost' = cost + 2000"
     },
     {
-      "id": "t_route_minor", "position": { "x": 660, "y": 480 },
-      "label": "Route Minor", "width": 20, "height": 50,
-      "isEnabled": false, "priority": 0, "delay": 0,
+      "id": "t_route_minor",
+      "position": {
+        "x": 660,
+        "y": 480
+      },
+      "label": "Route Minor",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
       "precondition": "severity >= 4",
-      "postcondition": "cost' = cost + 300;"
+      "postcondition": "cost' = cost + 300"
     },
     {
-      "id": "t_order_labs", "position": { "x": 830, "y": 120 },
-      "label": "Order Labs & Imaging", "width": 20, "height": 50,
-      "isEnabled": false, "priority": 0, "delay": 0,
+      "id": "t_order_labs",
+      "position": {
+        "x": 830,
+        "y": 120
+      },
+      "label": "Order Labs & Imaging",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
       "precondition": "",
-      "postcondition": "cost' = cost + 1200;"
+      "postcondition": "cost' = cost + 1200"
     },
     {
-      "id": "t_examine", "position": { "x": 830, "y": 300 },
-      "label": "Physician Exam", "width": 20, "height": 50,
-      "isEnabled": false, "priority": 0, "delay": 0,
+      "id": "t_examine",
+      "position": {
+        "x": 830,
+        "y": 300
+      },
+      "label": "Physician Exam",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
       "precondition": "",
-      "postcondition": "cost' = cost + 600;"
+      "postcondition": "cost' = cost + 600"
     },
     {
-      "id": "t_quick_assess", "position": { "x": 830, "y": 480 },
-      "label": "Nurse Assessment", "width": 20, "height": 50,
-      "isEnabled": false, "priority": 0, "delay": 0,
+      "id": "t_quick_assess",
+      "position": {
+        "x": 830,
+        "y": 480
+      },
+      "label": "Nurse Assessment",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
       "precondition": "",
-      "postcondition": "cost' = cost + 200;"
+      "postcondition": "cost' = cost + 200"
     },
     {
-      "id": "t_diagnose_critical", "position": { "x": 1010, "y": 120 },
-      "label": "Diagnose (Critical)", "width": 20, "height": 50,
-      "isEnabled": false, "priority": 0, "delay": 0,
-      "precondition": "",
-      "postcondition": ""
-    },
-    {
-      "id": "t_diagnose_urgent", "position": { "x": 1010, "y": 300 },
-      "label": "Diagnose (Urgent)", "width": 20, "height": 50,
-      "isEnabled": false, "priority": 0, "delay": 0,
-      "precondition": "",
-      "postcondition": ""
-    },
-    {
-      "id": "t_diagnose_minor", "position": { "x": 1010, "y": 480 },
-      "label": "Diagnose (Minor)", "width": 20, "height": 50,
-      "isEnabled": false, "priority": 0, "delay": 0,
-      "precondition": "",
-      "postcondition": ""
-    },
-    {
-      "id": "t_treat_surgery", "position": { "x": 1190, "y": 160 },
-      "label": "Surgical Intervention", "width": 20, "height": 50,
-      "isEnabled": false, "priority": 0, "delay": 0,
-      "precondition": "severity <= 2 && diagnosisCode >= 1",
-      "postcondition": "cost' = cost + 15000;"
-    },
-    {
-      "id": "t_treat_medication", "position": { "x": 1190, "y": 440 },
-      "label": "Prescribe Medication", "width": 20, "height": 50,
-      "isEnabled": false, "priority": 0, "delay": 0,
-      "precondition": "diagnosisCode == 0 || severity >= 3",
-      "postcondition": "cost' = cost + 400;"
-    },
-    {
-      "id": "t_post_surgery", "position": { "x": 1370, "y": 160 },
-      "label": "Post-Op Recovery", "width": 20, "height": 50,
-      "isEnabled": false, "priority": 0, "delay": 0,
-      "precondition": "",
-      "postcondition": "cost' = cost + 3000;"
-    },
-    {
-      "id": "t_post_medication", "position": { "x": 1370, "y": 440 },
-      "label": "Monitor Response", "width": 20, "height": 50,
-      "isEnabled": false, "priority": 0, "delay": 0,
+      "id": "t_diagnose_critical",
+      "position": {
+        "x": 1010,
+        "y": 120
+      },
+      "label": "Diagnose (Critical)",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
       "precondition": "",
       "postcondition": ""
     },
     {
-      "id": "t_admit", "position": { "x": 1550, "y": 180 },
-      "label": "Admit to Hospital", "width": 20, "height": 50,
-      "isEnabled": false, "priority": 0, "delay": 0,
-      "precondition": "severity <= 2 || (heartRate > 120)",
-      "postcondition": "cost' = cost + 8000;"
-    },
-    {
-      "id": "t_discharge", "position": { "x": 1550, "y": 420 },
-      "label": "Discharge Patient", "width": 20, "height": 50,
-      "isEnabled": false, "priority": 0, "delay": 0,
-      "precondition": "severity >= 3 && heartRate <= 120",
-      "postcondition": ""
-    },
-    {
-      "id": "t_close_admit", "position": { "x": 1730, "y": 180 },
-      "label": "Finalize Admission", "width": 20, "height": 50,
-      "isEnabled": false, "priority": 0, "delay": 0,
+      "id": "t_diagnose_urgent",
+      "position": {
+        "x": 1010,
+        "y": 300
+      },
+      "label": "Diagnose (Urgent)",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
       "precondition": "",
       "postcondition": ""
     },
     {
-      "id": "t_close_discharge", "position": { "x": 1730, "y": 420 },
-      "label": "Finalize Discharge", "width": 20, "height": 50,
-      "isEnabled": false, "priority": 0, "delay": 0,
+      "id": "t_diagnose_minor",
+      "position": {
+        "x": 1010,
+        "y": 480
+      },
+      "label": "Diagnose (Minor)",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": ""
+    },
+    {
+      "id": "t_treat_surgery",
+      "position": {
+        "x": 1190,
+        "y": 160
+      },
+      "label": "Surgical Intervention",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "severity <= 2 and diagnosisCode >= 1",
+      "postcondition": "cost' = cost + 15000"
+    },
+    {
+      "id": "t_treat_medication",
+      "position": {
+        "x": 1190,
+        "y": 440
+      },
+      "label": "Prescribe Medication",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "diagnosisCode = 0 or severity >= 3",
+      "postcondition": "cost' = cost + 400"
+    },
+    {
+      "id": "t_post_surgery",
+      "position": {
+        "x": 1370,
+        "y": 160
+      },
+      "label": "Post-Op Recovery",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "cost' = cost + 3000"
+    },
+    {
+      "id": "t_post_medication",
+      "position": {
+        "x": 1370,
+        "y": 440
+      },
+      "label": "Monitor Response",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": ""
+    },
+    {
+      "id": "t_admit",
+      "position": {
+        "x": 1550,
+        "y": 180
+      },
+      "label": "Admit to Hospital",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "severity <= 2 or (heartRate > 120)",
+      "postcondition": "cost' = cost + 8000"
+    },
+    {
+      "id": "t_discharge",
+      "position": {
+        "x": 1550,
+        "y": 420
+      },
+      "label": "Discharge Patient",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "severity >= 3 and heartRate <= 120",
+      "postcondition": ""
+    },
+    {
+      "id": "t_close_admit",
+      "position": {
+        "x": 1730,
+        "y": 180
+      },
+      "label": "Finalize Admission",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": ""
+    },
+    {
+      "id": "t_close_discharge",
+      "position": {
+        "x": 1730,
+        "y": 420
+      },
+      "label": "Finalize Discharge",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
       "precondition": "",
       "postcondition": ""
     }
   ],
   "arcs": [
-    { "id": "a1",  "source": "p_start",      "target": "t_register",        "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a2",  "source": "t_register",    "target": "p_registered",      "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a3",  "source": "p_registered",  "target": "t_assess_vitals",   "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a4",  "source": "t_assess_vitals","target": "p_vitals_taken",   "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a5",  "source": "p_vitals_taken", "target": "t_triage",         "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a6",  "source": "t_triage",       "target": "p_triaged",        "weight": 1, "type": "regular", "points": [], "label": "1" },
-
-    { "id": "a7",  "source": "p_triaged",   "target": "t_route_critical",  "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a8",  "source": "p_triaged",   "target": "t_route_urgent",    "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a9",  "source": "p_triaged",   "target": "t_route_minor",     "weight": 1, "type": "regular", "points": [], "label": "1" },
-
-    { "id": "a10", "source": "t_route_critical", "target": "p_critical",    "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a11", "source": "t_route_urgent",   "target": "p_urgent",      "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a12", "source": "t_route_minor",    "target": "p_minor",       "weight": 1, "type": "regular", "points": [], "label": "1" },
-
-    { "id": "a13", "source": "p_critical", "target": "t_order_labs",     "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a14", "source": "p_urgent",   "target": "t_examine",        "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a15", "source": "p_minor",    "target": "t_quick_assess",   "weight": 1, "type": "regular", "points": [], "label": "1" },
-
-    { "id": "a16", "source": "t_order_labs",   "target": "p_lab_ordered",  "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a17", "source": "t_examine",      "target": "p_exam_done",    "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a18", "source": "t_quick_assess", "target": "p_quick_check",  "weight": 1, "type": "regular", "points": [], "label": "1" },
-
-    { "id": "a19", "source": "p_lab_ordered", "target": "t_diagnose_critical", "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a20", "source": "p_exam_done",   "target": "t_diagnose_urgent",   "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a21", "source": "p_quick_check", "target": "t_diagnose_minor",    "weight": 1, "type": "regular", "points": [], "label": "1" },
-
-    { "id": "a22", "source": "t_diagnose_critical", "target": "p_diagnosed", "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a23", "source": "t_diagnose_urgent",   "target": "p_diagnosed", "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a24", "source": "t_diagnose_minor",    "target": "p_diagnosed", "weight": 1, "type": "regular", "points": [], "label": "1" },
-
-    { "id": "a25", "source": "p_diagnosed", "target": "t_treat_surgery",    "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a26", "source": "p_diagnosed", "target": "t_treat_medication",  "weight": 1, "type": "regular", "points": [], "label": "1" },
-
-    { "id": "a27", "source": "t_treat_surgery",    "target": "p_surgery",    "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a28", "source": "t_treat_medication",  "target": "p_medication", "weight": 1, "type": "regular", "points": [], "label": "1" },
-
-    { "id": "a29", "source": "p_surgery",    "target": "t_post_surgery",    "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a30", "source": "p_medication",  "target": "t_post_medication", "weight": 1, "type": "regular", "points": [], "label": "1" },
-
-    { "id": "a31", "source": "t_post_surgery",    "target": "p_post_treatment", "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a32", "source": "t_post_medication",  "target": "p_post_treatment", "weight": 1, "type": "regular", "points": [], "label": "1" },
-
-    { "id": "a33", "source": "p_post_treatment", "target": "t_admit",     "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a34", "source": "p_post_treatment", "target": "t_discharge",  "weight": 1, "type": "regular", "points": [], "label": "1" },
-
-    { "id": "a35", "source": "t_admit",     "target": "p_admitted",    "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a36", "source": "t_discharge",  "target": "p_discharged", "weight": 1, "type": "regular", "points": [], "label": "1" },
-
-    { "id": "a37", "source": "p_admitted",   "target": "t_close_admit",     "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a38", "source": "p_discharged", "target": "t_close_discharge", "weight": 1, "type": "regular", "points": [], "label": "1" },
-
-    { "id": "a39", "source": "t_close_admit",     "target": "p_end", "weight": 1, "type": "regular", "points": [], "label": "1" },
-    { "id": "a40", "source": "t_close_discharge",  "target": "p_end", "weight": 1, "type": "regular", "points": [], "label": "1" }
+    {
+      "id": "a1",
+      "source": "p_start",
+      "target": "t_register",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a2",
+      "source": "t_register",
+      "target": "p_registered",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a3",
+      "source": "p_registered",
+      "target": "t_assess_vitals",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a4",
+      "source": "t_assess_vitals",
+      "target": "p_vitals_taken",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a5",
+      "source": "p_vitals_taken",
+      "target": "t_triage",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a6",
+      "source": "t_triage",
+      "target": "p_triaged",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a7",
+      "source": "p_triaged",
+      "target": "t_route_critical",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a8",
+      "source": "p_triaged",
+      "target": "t_route_urgent",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a9",
+      "source": "p_triaged",
+      "target": "t_route_minor",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a10",
+      "source": "t_route_critical",
+      "target": "p_critical",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a11",
+      "source": "t_route_urgent",
+      "target": "p_urgent",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a12",
+      "source": "t_route_minor",
+      "target": "p_minor",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a13",
+      "source": "p_critical",
+      "target": "t_order_labs",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a14",
+      "source": "p_urgent",
+      "target": "t_examine",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a15",
+      "source": "p_minor",
+      "target": "t_quick_assess",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a16",
+      "source": "t_order_labs",
+      "target": "p_lab_ordered",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a17",
+      "source": "t_examine",
+      "target": "p_exam_done",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a18",
+      "source": "t_quick_assess",
+      "target": "p_quick_check",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a19",
+      "source": "p_lab_ordered",
+      "target": "t_diagnose_critical",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a20",
+      "source": "p_exam_done",
+      "target": "t_diagnose_urgent",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a21",
+      "source": "p_quick_check",
+      "target": "t_diagnose_minor",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a22",
+      "source": "t_diagnose_critical",
+      "target": "p_diagnosed",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a23",
+      "source": "t_diagnose_urgent",
+      "target": "p_diagnosed",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a24",
+      "source": "t_diagnose_minor",
+      "target": "p_diagnosed",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a25",
+      "source": "p_diagnosed",
+      "target": "t_treat_surgery",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a26",
+      "source": "p_diagnosed",
+      "target": "t_treat_medication",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a27",
+      "source": "t_treat_surgery",
+      "target": "p_surgery",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a28",
+      "source": "t_treat_medication",
+      "target": "p_medication",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a29",
+      "source": "p_surgery",
+      "target": "t_post_surgery",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a30",
+      "source": "p_medication",
+      "target": "t_post_medication",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a31",
+      "source": "t_post_surgery",
+      "target": "p_post_treatment",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a32",
+      "source": "t_post_medication",
+      "target": "p_post_treatment",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a33",
+      "source": "p_post_treatment",
+      "target": "t_admit",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a34",
+      "source": "p_post_treatment",
+      "target": "t_discharge",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a35",
+      "source": "t_admit",
+      "target": "p_admitted",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a36",
+      "source": "t_discharge",
+      "target": "p_discharged",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a37",
+      "source": "p_admitted",
+      "target": "t_close_admit",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a38",
+      "source": "p_discharged",
+      "target": "t_close_discharge",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a39",
+      "source": "t_close_admit",
+      "target": "p_end",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a40",
+      "source": "t_close_discharge",
+      "target": "p_end",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    }
   ],
   "dataVariables": [
-    { "id": "var_age",       "name": "patientAge",    "type": "number", "currentValue": 0,   "description": "Patient age in years (randomised 5–84 on registration)" },
-    { "id": "var_severity",  "name": "severity",      "type": "number", "currentValue": 0,   "description": "Triage severity level 1 (critical) to 5 (minor)" },
-    { "id": "var_hr",        "name": "heartRate",     "type": "number", "currentValue": 0,   "description": "Heart rate in bpm (randomised 60–139 on registration)" },
-    { "id": "var_diag",      "name": "diagnosisCode", "type": "number", "currentValue": 0,   "description": "Diagnosis code: 0 = manageable, 1 = surgical, 2 = complex" },
-    { "id": "var_cost",      "name": "cost",          "type": "number", "currentValue": 0,   "description": "Cumulative treatment cost in USD" }
+    {
+      "id": "var_age",
+      "name": "patientAge",
+      "type": "real",
+      "currentValue": 0,
+      "description": "Patient age in years (randomised 5–84 on registration)"
+    },
+    {
+      "id": "var_severity",
+      "name": "severity",
+      "type": "real",
+      "currentValue": 0,
+      "description": "Triage severity level 1 (critical) to 5 (minor)"
+    },
+    {
+      "id": "var_hr",
+      "name": "heartRate",
+      "type": "real",
+      "currentValue": 0,
+      "description": "Heart rate in bpm (randomised 60–139 on registration)"
+    },
+    {
+      "id": "var_diag",
+      "name": "diagnosisCode",
+      "type": "real",
+      "currentValue": 0,
+      "description": "Diagnosis code: 0 = manageable, 1 = surgical, 2 = complex"
+    },
+    {
+      "id": "var_cost",
+      "name": "cost",
+      "type": "real",
+      "currentValue": 0,
+      "description": "Cumulative treatment cost in USD"
+    }
   ]
 }

--- a/public/examples/DPN-Fibonacci(n).json
+++ b/public/examples/DPN-Fibonacci(n).json
@@ -4,7 +4,10 @@
   "places": [
     {
       "id": "P_Init",
-      "position": { "x": 30, "y": 200 },
+      "position": {
+        "x": 30,
+        "y": 200
+      },
       "label": "P_Init",
       "tokens": 1,
       "capacity": null,
@@ -12,7 +15,10 @@
     },
     {
       "id": "P_Loop",
-      "position": { "x": 300, "y": 200 },
+      "position": {
+        "x": 300,
+        "y": 200
+      },
       "label": "P_Loop",
       "tokens": 0,
       "capacity": null,
@@ -20,7 +26,10 @@
     },
     {
       "id": "P_Update",
-      "position": { "x": 300, "y": -50 },
+      "position": {
+        "x": 300,
+        "y": -50
+      },
       "label": "P_Update",
       "tokens": 0,
       "capacity": null,
@@ -28,7 +37,10 @@
     },
     {
       "id": "P_U2",
-      "position": { "x": 580, "y": -50 },
+      "position": {
+        "x": 580,
+        "y": -50
+      },
       "label": "P_U2",
       "tokens": 0,
       "capacity": null,
@@ -36,7 +48,10 @@
     },
     {
       "id": "P_U3",
-      "position": { "x": 700, "y": 90 },
+      "position": {
+        "x": 700,
+        "y": 90
+      },
       "label": "P_U3",
       "tokens": 0,
       "capacity": null,
@@ -44,7 +59,10 @@
     },
     {
       "id": "P_U4",
-      "position": { "x": 590, "y": 200 },
+      "position": {
+        "x": 590,
+        "y": 200
+      },
       "label": "P_U4",
       "tokens": 0,
       "capacity": null,
@@ -52,7 +70,10 @@
     },
     {
       "id": "P_Done",
-      "position": { "x": 300, "y": 520 },
+      "position": {
+        "x": 300,
+        "y": 520
+      },
       "label": "P_Done",
       "tokens": 0,
       "capacity": null,
@@ -63,7 +84,10 @@
   "transitions": [
     {
       "id": "T_Setup",
-      "position": { "x": 150, "y": 200 },
+      "position": {
+        "x": 150,
+        "y": 200
+      },
       "label": "T_Setup",
       "width": 20,
       "height": 50,
@@ -71,11 +95,14 @@
       "priority": 1,
       "delay": 0,
       "precondition": "",
-      "postcondition": "a' = 0; b' = 1; i' = 1;"
+      "postcondition": "a' = 0 and b' = 1 and i' = 1"
     },
     {
       "id": "T_CheckLoop",
-      "position": { "x": 300, "y": 70 },
+      "position": {
+        "x": 300,
+        "y": 70
+      },
       "label": "T_CheckLoop",
       "width": 20,
       "height": 50,
@@ -87,7 +114,10 @@
     },
     {
       "id": "T_CheckDone",
-      "position": { "x": 300, "y": 360 },
+      "position": {
+        "x": 300,
+        "y": 360
+      },
       "label": "T_CheckDone",
       "width": 20,
       "height": 50,
@@ -95,11 +125,14 @@
       "priority": 1,
       "delay": 0,
       "precondition": "i >= n;",
-      "postcondition": "result' = b;"
+      "postcondition": "result' = b"
     },
     {
       "id": "T_CalcTemp",
-      "position": { "x": 460, "y": -50 },
+      "position": {
+        "x": 460,
+        "y": -50
+      },
       "label": "T_CalcTemp",
       "width": 20,
       "height": 50,
@@ -107,11 +140,14 @@
       "priority": 1,
       "delay": 0,
       "precondition": "",
-      "postcondition": "temp' = a + b;"
+      "postcondition": "temp' = a + b"
     },
     {
       "id": "T_SetA",
-      "position": { "x": 700, "y": -50 },
+      "position": {
+        "x": 700,
+        "y": -50
+      },
       "label": "T_SetA",
       "width": 20,
       "height": 50,
@@ -119,11 +155,14 @@
       "priority": 1,
       "delay": 0,
       "precondition": "",
-      "postcondition": "a' = b;"
+      "postcondition": "a' = b"
     },
     {
       "id": "T_SetB",
-      "position": { "x": 700, "y": 200 },
+      "position": {
+        "x": 700,
+        "y": 200
+      },
       "label": "T_SetB",
       "width": 20,
       "height": 50,
@@ -131,11 +170,14 @@
       "priority": 1,
       "delay": 0,
       "precondition": "",
-      "postcondition": "b' = temp;"
+      "postcondition": "b' = temp"
     },
     {
       "id": "T_IncI",
-      "position": { "x": 470, "y": 200 },
+      "position": {
+        "x": 470,
+        "y": 200
+      },
       "label": "T_IncI",
       "width": 20,
       "height": 50,
@@ -143,7 +185,7 @@
       "priority": 1,
       "delay": 0,
       "precondition": "",
-      "postcondition": "i' = i + 1;"
+      "postcondition": "i' = i + 1"
     }
   ],
   "arcs": [
@@ -278,42 +320,42 @@
     {
       "id": "var_n",
       "name": "n",
-      "type": "number",
+      "type": "real",
       "currentValue": 7,
       "description": "Input value for which Fibonacci is computed"
     },
     {
       "id": "var_a",
       "name": "a",
-      "type": "number",
+      "type": "real",
       "currentValue": 0,
       "description": "Holds F(i-2)"
     },
     {
       "id": "var_b",
       "name": "b",
-      "type": "number",
+      "type": "real",
       "currentValue": 0,
       "description": "Holds F(i-1)"
     },
     {
       "id": "var_temp",
       "name": "temp",
-      "type": "number",
+      "type": "real",
       "currentValue": 0,
       "description": "Temporary for sum a+b"
     },
     {
       "id": "var_i",
       "name": "i",
-      "type": "number",
+      "type": "real",
       "currentValue": 0,
       "description": "Loop counter"
     },
     {
       "id": "var_result",
       "name": "result",
-      "type": "number",
+      "type": "real",
       "currentValue": 0,
       "description": "Final Fibonacci(n)"
     }

--- a/public/examples/DPN-Order-Processing.json
+++ b/public/examples/DPN-Order-Processing.json
@@ -1,1 +1,405 @@
-{"id":"simple-order-process","name":"Simple Order Processing with Data","description":"A data Petri net example of a simple order processing system","places":[{"id":"p1","position":{"x":100,"y":200},"label":"New Order","tokens":0,"capacity":null,"radius":20},{"id":"p2","position":{"x":250,"y":200},"label":"Order Received","tokens":0,"capacity":null,"radius":20},{"id":"p3","position":{"x":410,"y":200},"label":"Order Validated","tokens":0,"capacity":null,"radius":20},{"id":"p4","position":{"x":580,"y":120},"label":"Order Approved","tokens":0,"capacity":null,"radius":20},{"id":"p5","position":{"x":700,"y":280},"label":"Order Rejected","tokens":0,"capacity":null,"radius":20},{"id":"p6","position":{"x":740,"y":120},"label":"Order Shipped","tokens":0,"capacity":null,"radius":20},{"id":"p7","position":{"x":940,"y":120},"label":"Process Complete","tokens":0,"capacity":null,"radius":20},{"id":"p8","position":{"x":10,"y":80},"label":"Start","tokens":1,"capacity":null,"radius":20}],"transitions":[{"id":"t1","position":{"x":100,"y":80},"label":"Create Order","width":20,"height":50,"isEnabled":true,"priority":1,"delay":0,"precondition":"","postcondition":"orderId' = orderId + 1; orderAmount' = Math.floor(Math.random() * 1000) + 10;"},{"id":"t2","position":{"x":170,"y":200},"label":"Receive Order","width":20,"height":50,"isEnabled":false,"priority":1,"delay":0,"precondition":"","postcondition":"status' = \"received\";"},{"id":"t3","position":{"x":320,"y":200},"label":"Validate Order","width":20,"height":50,"isEnabled":false,"priority":1,"delay":0,"precondition":"orderAmount > 0","postcondition":"status' = \"validated\";"},{"id":"t4","position":{"x":480,"y":120},"label":"Approve Order","width":20,"height":50,"isEnabled":false,"priority":1,"delay":0,"precondition":"orderAmount <= 500","postcondition":"status' = \"approved\";"},{"id":"t5","position":{"x":480,"y":280},"label":"Reject Order","width":20,"height":50,"isEnabled":false,"priority":1,"delay":0,"precondition":"orderAmount > 500","postcondition":"status' = \"rejected\"; rejectedCount' = rejectedCount + 1;"},{"id":"t6","position":{"x":660,"y":120},"label":"Ship Order","width":20,"height":50,"isEnabled":false,"priority":1,"delay":0,"precondition":"","postcondition":"status' = \"shipped\"; shippedCount' = shippedCount + 1;"},{"id":"t7","position":{"x":850,"y":120},"label":"Complete","width":20,"height":50,"isEnabled":false,"priority":1,"delay":0,"precondition":"","postcondition":"processedOrders' = processedOrders + 1;"},{"id":"c7dbf061-45e5-4bdb-8c88-c7c3290b7452","position":{"x":940,"y":280},"label":"T8","width":20,"height":50,"isEnabled":false,"priority":1,"delay":0}],"arcs":[{"id":"a2","source":"t1","target":"p1","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a4","source":"p1","target":"t2","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a5","source":"t2","target":"p2","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a6","source":"p2","target":"t3","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a7","source":"t3","target":"p3","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a8","source":"p3","target":"t4","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a9","source":"p3","target":"t5","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a10","source":"t4","target":"p4","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a11","source":"t5","target":"p5","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a12","source":"p4","target":"t6","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a13","source":"t6","target":"p6","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a14","source":"p6","target":"t7","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a16","source":"t7","target":"p7","weight":1,"type":"regular","points":[],"label":"1"},{"id":"c022efc7-b738-49d5-b3be-dcca0bfc3a19","source":"p8","target":"t1","weight":1,"type":"regular","points":[],"label":"1"},{"id":"d27f3286-4e94-4c8d-b090-e5489aa111df","source":"p5","target":"c7dbf061-45e5-4bdb-8c88-c7c3290b7452","weight":1,"type":"regular","points":[],"label":"1"},{"id":"bda1fbdf-f58b-4cdd-94f3-4afd24bbdd01","source":"c7dbf061-45e5-4bdb-8c88-c7c3290b7452","target":"p7","weight":1,"type":"regular","points":[],"label":"1"}],"dataVariables":[{"id":"var1","name":"orderId","type":"number","currentValue":1000,"description":"Unique order identifier"},{"id":"var2","name":"orderAmount","type":"number","currentValue":0,"description":"Total order amount in dollars"},{"id":"var3","name":"status","type":"string","currentValue":"new","description":"Current status of the order"},{"id":"var4","name":"shippedCount","type":"number","currentValue":0,"description":"Number of orders shipped"},{"id":"var5","name":"rejectedCount","type":"number","currentValue":0,"description":"Number of orders rejected"},{"id":"var6","name":"processedOrders","type":"number","currentValue":0,"description":"Total number of processed orders"}]}
+{
+  "id": "simple-order-process",
+  "name": "Simple Order Processing with Data",
+  "description": "A data Petri net example of a simple order processing system",
+  "places": [
+    {
+      "id": "p1",
+      "position": {
+        "x": 100,
+        "y": 200
+      },
+      "label": "New Order",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "p2",
+      "position": {
+        "x": 250,
+        "y": 200
+      },
+      "label": "Order Received",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "p3",
+      "position": {
+        "x": 410,
+        "y": 200
+      },
+      "label": "Order Validated",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "p4",
+      "position": {
+        "x": 580,
+        "y": 120
+      },
+      "label": "Order Approved",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "p5",
+      "position": {
+        "x": 700,
+        "y": 280
+      },
+      "label": "Order Rejected",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "p6",
+      "position": {
+        "x": 740,
+        "y": 120
+      },
+      "label": "Order Shipped",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "p7",
+      "position": {
+        "x": 940,
+        "y": 120
+      },
+      "label": "Process Complete",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "p8",
+      "position": {
+        "x": 10,
+        "y": 80
+      },
+      "label": "Start",
+      "tokens": 1,
+      "capacity": null,
+      "radius": 20
+    }
+  ],
+  "transitions": [
+    {
+      "id": "t1",
+      "position": {
+        "x": 100,
+        "y": 80
+      },
+      "label": "Create Order",
+      "width": 20,
+      "height": 50,
+      "isEnabled": true,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "orderId' = orderId + 1 and orderAmount' >= 10 and orderAmount' <= 1010"
+    },
+    {
+      "id": "t2",
+      "position": {
+        "x": 170,
+        "y": 200
+      },
+      "label": "Receive Order",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "status' = 1"
+    },
+    {
+      "id": "t3",
+      "position": {
+        "x": 320,
+        "y": 200
+      },
+      "label": "Validate Order",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "orderAmount > 0",
+      "postcondition": "status' = 2"
+    },
+    {
+      "id": "t4",
+      "position": {
+        "x": 480,
+        "y": 120
+      },
+      "label": "Approve Order",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "orderAmount <= 500",
+      "postcondition": "status' = 3"
+    },
+    {
+      "id": "t5",
+      "position": {
+        "x": 480,
+        "y": 280
+      },
+      "label": "Reject Order",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "orderAmount > 500",
+      "postcondition": "status' = 4 and rejectedCount' = rejectedCount + 1"
+    },
+    {
+      "id": "t6",
+      "position": {
+        "x": 660,
+        "y": 120
+      },
+      "label": "Ship Order",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "status' = 5 and shippedCount' = shippedCount + 1"
+    },
+    {
+      "id": "t7",
+      "position": {
+        "x": 850,
+        "y": 120
+      },
+      "label": "Complete",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "processedOrders' = processedOrders + 1"
+    },
+    {
+      "id": "c7dbf061-45e5-4bdb-8c88-c7c3290b7452",
+      "position": {
+        "x": 940,
+        "y": 280
+      },
+      "label": "T8",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0
+    }
+  ],
+  "arcs": [
+    {
+      "id": "a2",
+      "source": "t1",
+      "target": "p1",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a4",
+      "source": "p1",
+      "target": "t2",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a5",
+      "source": "t2",
+      "target": "p2",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a6",
+      "source": "p2",
+      "target": "t3",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a7",
+      "source": "t3",
+      "target": "p3",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a8",
+      "source": "p3",
+      "target": "t4",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a9",
+      "source": "p3",
+      "target": "t5",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a10",
+      "source": "t4",
+      "target": "p4",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a11",
+      "source": "t5",
+      "target": "p5",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a12",
+      "source": "p4",
+      "target": "t6",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a13",
+      "source": "t6",
+      "target": "p6",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a14",
+      "source": "p6",
+      "target": "t7",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a16",
+      "source": "t7",
+      "target": "p7",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "c022efc7-b738-49d5-b3be-dcca0bfc3a19",
+      "source": "p8",
+      "target": "t1",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "d27f3286-4e94-4c8d-b090-e5489aa111df",
+      "source": "p5",
+      "target": "c7dbf061-45e5-4bdb-8c88-c7c3290b7452",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "bda1fbdf-f58b-4cdd-94f3-4afd24bbdd01",
+      "source": "c7dbf061-45e5-4bdb-8c88-c7c3290b7452",
+      "target": "p7",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    }
+  ],
+  "dataVariables": [
+    {
+      "id": "var1",
+      "name": "orderId",
+      "type": "real",
+      "currentValue": 1000,
+      "description": "Unique order identifier"
+    },
+    {
+      "id": "var2",
+      "name": "orderAmount",
+      "type": "real",
+      "currentValue": 0,
+      "description": "Total order amount in dollars"
+    },
+    {
+      "id": "var3",
+      "name": "status",
+      "type": "int",
+      "currentValue": 0,
+      "description": "Current status of the order (0=new, 1=received, 2=validated, 3=approved, 4=rejected, 5=shipped)"
+    },
+    {
+      "id": "var4",
+      "name": "shippedCount",
+      "type": "real",
+      "currentValue": 0,
+      "description": "Number of orders shipped"
+    },
+    {
+      "id": "var5",
+      "name": "rejectedCount",
+      "type": "real",
+      "currentValue": 0,
+      "description": "Number of orders rejected"
+    },
+    {
+      "id": "var6",
+      "name": "processedOrders",
+      "type": "real",
+      "currentValue": 0,
+      "description": "Total number of processed orders"
+    }
+  ]
+}

--- a/public/examples/Digital transfer: Discharge.json
+++ b/public/examples/Digital transfer: Discharge.json
@@ -1,1 +1,305 @@
-{"id":"net1","name":"Digital whiteboard: discharge","description":"","places":[{"id":"start","position":{"x":-400,"y":-300},"label":"start","tokens":1,"capacity":null,"radius":20},{"id":"p1","position":{"x":-200,"y":-300},"label":"p1","tokens":0,"capacity":null,"radius":20},{"id":"p2","position":{"x":0,"y":-300},"label":"p2","tokens":0,"capacity":null,"radius":20},{"id":"p3","position":{"x":190,"y":-110},"label":"p3","tokens":0,"capacity":null,"radius":20},{"id":"p4","position":{"x":180,"y":-420},"label":"p4","tokens":0,"capacity":null,"radius":20},{"id":"end","position":{"x":470,"y":-290},"label":"end","tokens":0,"capacity":null,"radius":20}],"transitions":[{"id":"bed1","position":{"x":-300,"y":-300},"label":"bed status","width":20,"height":50,"isEnabled":true,"priority":1,"delay":0,"precondition":"","postcondition":"(statusLedig' == True)"},{"id":"bed2","position":{"x":-100,"y":-300},"label":"bed status","width":20,"height":50,"isEnabled":false,"priority":1,"delay":0,"precondition":"","postcondition":"(statusLedig' == True)"},{"id":"mth1","position":{"x":0,"y":-420},"label":"MoveHistory","width":20,"height":50,"isEnabled":false,"priority":1,"delay":0,"precondition":"","postcondition":"(org1' == org1)"},{"id":"mth2","position":{"x":350,"y":-420},"label":"MoveHistory","width":20,"height":50,"isEnabled":false,"priority":1,"delay":0,"precondition":"","postcondition":"(org2' == org2)"},{"id":"tra1","position":{"x":0,"y":-110},"label":"Transfer","width":20,"height":50,"isEnabled":false,"priority":1,"delay":0,"precondition":"","postcondition":""},{"id":"tra2","position":{"x":360,"y":-110},"label":"Transfer","width":20,"height":50,"isEnabled":false,"priority":1,"delay":0,"precondition":"","postcondition":""}],"arcs":[{"id":"04efe31d-06a3-4d21-9bf5-780006a2b5b9","source":"start","target":"bed1","weight":1,"type":"regular","points":[],"label":"1"},{"id":"5db4f494-70ad-4960-be7c-4a9d8b5d8ade","source":"bed1","target":"p1","weight":1,"type":"regular","points":[],"label":"1"},{"id":"5f3961b9-4121-45a0-8822-6aebbd21b4f0","source":"p1","target":"bed2","weight":1,"type":"regular","points":[],"label":"1"},{"id":"273a672f-a168-43dd-b740-a64c4b51b9ae","source":"bed2","target":"p2","weight":1,"type":"regular","points":[],"label":"1"},{"id":"27031388-578f-453b-a85d-5d6094b847b9","source":"p2","target":"mth1","weight":1,"type":"regular","points":[],"label":"1"},{"id":"0a6ed3c2-0dff-442e-896c-5b1b3ec80bef","source":"mth1","target":"p4","weight":1,"type":"regular","points":[],"label":"1"},{"id":"350cc8fd-997e-4af5-af04-8084beabdc96","source":"p4","target":"mth2","weight":1,"type":"regular","points":[],"label":"1"},{"id":"03bacb96-4a34-4842-bf7a-cd080fcc2e43","source":"mth2","target":"end","weight":1,"type":"regular","points":[],"label":"1"},{"id":"50b79674-25fd-4eda-9bb4-66a3001084ad","source":"p2","target":"tra1","weight":1,"type":"regular","points":[],"label":"1"},{"id":"ad99fcb7-f975-4f1e-89ef-9b093952c3a7","source":"tra1","target":"p3","weight":1,"type":"regular","points":[],"label":"1"},{"id":"b337df9f-bea5-4ce9-af2c-441d430f6798","source":"p3","target":"tra2","weight":1,"type":"regular","points":[],"label":"1"},{"id":"898f54e0-8548-4eaa-8db5-5f8ef719a4ba","source":"tra2","target":"end","weight":1,"type":"regular","points":[],"label":"1"}],"dataVariables":[{"id":"49781d0a-24d8-42fd-ab4c-808270634e92","name":"org1","type":"number","currentValue":0,"description":""},{"id":"134a9d4e-8e59-4d0a-b3ab-acf354524387","name":"org2","type":"number","currentValue":0,"description":""},{"id":"fd11bf6d-d0e5-4204-8ea3-16fe9113f2a6","name":"statusLedig","type":"boolean","currentValue":false,"description":""},{"id":"d4c56d91-04fe-41d8-af07-0d36c8cd2165","name":"valueHistory","type":"boolean","currentValue":false,"description":""}]}
+{
+  "id": "net1",
+  "name": "Digital whiteboard: discharge",
+  "description": "",
+  "places": [
+    {
+      "id": "start",
+      "position": {
+        "x": -400,
+        "y": -300
+      },
+      "label": "start",
+      "tokens": 1,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "p1",
+      "position": {
+        "x": -200,
+        "y": -300
+      },
+      "label": "p1",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "p2",
+      "position": {
+        "x": 0,
+        "y": -300
+      },
+      "label": "p2",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "p3",
+      "position": {
+        "x": 190,
+        "y": -110
+      },
+      "label": "p3",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "p4",
+      "position": {
+        "x": 180,
+        "y": -420
+      },
+      "label": "p4",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "end",
+      "position": {
+        "x": 470,
+        "y": -290
+      },
+      "label": "end",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    }
+  ],
+  "transitions": [
+    {
+      "id": "bed1",
+      "position": {
+        "x": -300,
+        "y": -300
+      },
+      "label": "bed status",
+      "width": 20,
+      "height": 50,
+      "isEnabled": true,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "(statusLedig' = True)"
+    },
+    {
+      "id": "bed2",
+      "position": {
+        "x": -100,
+        "y": -300
+      },
+      "label": "bed status",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "(statusLedig' = True)"
+    },
+    {
+      "id": "mth1",
+      "position": {
+        "x": 0,
+        "y": -420
+      },
+      "label": "MoveHistory",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "(org1' = org1)"
+    },
+    {
+      "id": "mth2",
+      "position": {
+        "x": 350,
+        "y": -420
+      },
+      "label": "MoveHistory",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "(org2' = org2)"
+    },
+    {
+      "id": "tra1",
+      "position": {
+        "x": 0,
+        "y": -110
+      },
+      "label": "Transfer",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": ""
+    },
+    {
+      "id": "tra2",
+      "position": {
+        "x": 360,
+        "y": -110
+      },
+      "label": "Transfer",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": ""
+    }
+  ],
+  "arcs": [
+    {
+      "id": "04efe31d-06a3-4d21-9bf5-780006a2b5b9",
+      "source": "start",
+      "target": "bed1",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "5db4f494-70ad-4960-be7c-4a9d8b5d8ade",
+      "source": "bed1",
+      "target": "p1",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "5f3961b9-4121-45a0-8822-6aebbd21b4f0",
+      "source": "p1",
+      "target": "bed2",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "273a672f-a168-43dd-b740-a64c4b51b9ae",
+      "source": "bed2",
+      "target": "p2",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "27031388-578f-453b-a85d-5d6094b847b9",
+      "source": "p2",
+      "target": "mth1",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "0a6ed3c2-0dff-442e-896c-5b1b3ec80bef",
+      "source": "mth1",
+      "target": "p4",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "350cc8fd-997e-4af5-af04-8084beabdc96",
+      "source": "p4",
+      "target": "mth2",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "03bacb96-4a34-4842-bf7a-cd080fcc2e43",
+      "source": "mth2",
+      "target": "end",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "50b79674-25fd-4eda-9bb4-66a3001084ad",
+      "source": "p2",
+      "target": "tra1",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "ad99fcb7-f975-4f1e-89ef-9b093952c3a7",
+      "source": "tra1",
+      "target": "p3",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "b337df9f-bea5-4ce9-af2c-441d430f6798",
+      "source": "p3",
+      "target": "tra2",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "898f54e0-8548-4eaa-8db5-5f8ef719a4ba",
+      "source": "tra2",
+      "target": "end",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    }
+  ],
+  "dataVariables": [
+    {
+      "id": "49781d0a-24d8-42fd-ab4c-808270634e92",
+      "name": "org1",
+      "type": "real",
+      "currentValue": 0,
+      "description": ""
+    },
+    {
+      "id": "134a9d4e-8e59-4d0a-b3ab-acf354524387",
+      "name": "org2",
+      "type": "real",
+      "currentValue": 0,
+      "description": ""
+    },
+    {
+      "id": "fd11bf6d-d0e5-4204-8ea3-16fe9113f2a6",
+      "name": "statusLedig",
+      "type": "bool",
+      "currentValue": false,
+      "description": ""
+    },
+    {
+      "id": "d4c56d91-04fe-41d8-af07-0d36c8cd2165",
+      "name": "valueHistory",
+      "type": "bool",
+      "currentValue": false,
+      "description": ""
+    }
+  ]
+}

--- a/public/examples/Digital whiteboard: Transfer.json
+++ b/public/examples/Digital whiteboard: Transfer.json
@@ -1,1 +1,309 @@
-{"id":"net1","name":"Digital whiteboard: transfer","description":"","places":[{"id":"start","position":{"x":-600,"y":-350},"label":"start","tokens":1,"capacity":null,"radius":20},{"id":"p1","position":{"x":-400,"y":-150},"label":"p1","tokens":0,"capacity":null,"radius":20},{"id":"p2","position":{"x":-200,"y":-150},"label":"p2","tokens":0,"capacity":null,"radius":20},{"id":"p3","position":{"x":0,"y":-150},"label":"p3","tokens":0,"capacity":null,"radius":20},{"id":"p4","position":{"x":200,"y":-150},"label":"p4","tokens":0,"capacity":null,"radius":20},{"id":"p5","position":{"x":400,"y":-150},"label":"p5","tokens":0,"capacity":null,"radius":20},{"id":"end","position":{"x":600,"y":-150},"label":"end","tokens":0,"capacity":null,"radius":20}],"transitions":[{"id":"bed1","position":{"x":-500,"y":-350},"label":"bed status","width":20,"height":50,"isEnabled":true,"priority":1,"delay":0,"precondition":"","postcondition":"org1' > 0"},{"id":"bed2","position":{"x":-300,"y":-350},"label":"bed status","width":20,"height":50,"isEnabled":false,"priority":1,"delay":0,"precondition":"","postcondition":"org2' > 0"},{"id":"eom1","position":{"x":-100,"y":-350},"label":"Eom","width":20,"height":50,"isEnabled":false,"priority":1,"delay":0,"precondition":"","postcondition":"roomTransfer' = true"},{"id":"eom2","position":{"x":100,"y":-350},"label":"Eom","width":20,"height":50,"isEnabled":false,"priority":1,"delay":0,"precondition":"","postcondition":"roomTransfer' = true"},{"id":"tra1","position":{"x":300,"y":-350},"label":"Transfer","width":20,"height":50,"isEnabled":false,"priority":1,"delay":0,"precondition":"org1 != 207","postcondition":""},{"id":"tra2","position":{"x":500,"y":-350},"label":"Transfer","width":20,"height":50,"isEnabled":false,"priority":1,"delay":0,"precondition":"org1 != 207","postcondition":""}],"arcs":[{"id":"252bb7b2-6fce-42a3-bd35-359f046403c7","source":"start","target":"bed1","weight":1,"type":"regular","points":[],"label":"1"},{"id":"facafde5-87a1-492b-b6e7-21ecf3c859f0","source":"bed1","target":"p1","weight":1,"type":"regular","points":[],"label":"1"},{"id":"2df0fbbb-0499-47aa-8792-b81a38675f37","source":"p1","target":"bed2","weight":1,"type":"regular","points":[],"label":"1"},{"id":"f33c1710-04f7-4bdf-b0a2-cd5bace9ac0f","source":"bed2","target":"p2","weight":1,"type":"regular","points":[],"label":"1"},{"id":"2f799c40-357b-4cc5-bbb6-4819c1fe0f92","source":"p2","target":"eom1","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a13af8a1-817d-4e9e-bcaf-b1e6f09bdf5c","source":"eom1","target":"p3","weight":1,"type":"regular","points":[],"label":"1"},{"id":"0a544666-1a54-4fde-afdd-1499fbd04ec6","source":"p3","target":"eom2","weight":1,"type":"regular","points":[],"label":"1"},{"id":"698214a5-bc8f-478a-9ac7-61d210f36a40","source":"eom2","target":"p4","weight":1,"type":"regular","points":[],"label":"1"},{"id":"093a9fef-61aa-44f8-ae27-14689b246c16","source":"p4","target":"tra1","weight":1,"type":"regular","points":[],"label":"1"},{"id":"162d2464-c1a5-4ef2-80e1-a69ce26e9257","source":"tra1","target":"p5","weight":1,"type":"regular","points":[],"label":"1"},{"id":"5e8e1eee-2abd-43d9-b843-3f72dc65f058","source":"p5","target":"tra2","weight":1,"type":"regular","points":[],"label":"1"},{"id":"bcb75f6d-81b9-44e8-b54d-e0a65ded2872","source":"tra2","target":"end","weight":1,"type":"regular","points":[],"label":"1"}],"dataVariables":[{"id":"da368d15-8108-4867-9e5f-5be16716ceb2","name":"org1","type":"int","currentValue":1,"description":""},{"id":"e161c7b3-e5d8-4a44-aec6-981c51e8f7d6","name":"org2","type":"int","currentValue":1,"description":""},{"id":"16b8727b-5877-4b4d-9605-4f110cfa28a9","name":"roomTransfer","type":"boolean","currentValue":true,"description":""}]}
+{
+  "id": "net1",
+  "name": "Digital whiteboard: transfer",
+  "description": "",
+  "places": [
+    {
+      "id": "start",
+      "position": {
+        "x": -600,
+        "y": -350
+      },
+      "label": "start",
+      "tokens": 1,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "p1",
+      "position": {
+        "x": -400,
+        "y": -150
+      },
+      "label": "p1",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "p2",
+      "position": {
+        "x": -200,
+        "y": -150
+      },
+      "label": "p2",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "p3",
+      "position": {
+        "x": 0,
+        "y": -150
+      },
+      "label": "p3",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "p4",
+      "position": {
+        "x": 200,
+        "y": -150
+      },
+      "label": "p4",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "p5",
+      "position": {
+        "x": 400,
+        "y": -150
+      },
+      "label": "p5",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "end",
+      "position": {
+        "x": 600,
+        "y": -150
+      },
+      "label": "end",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    }
+  ],
+  "transitions": [
+    {
+      "id": "bed1",
+      "position": {
+        "x": -500,
+        "y": -350
+      },
+      "label": "bed status",
+      "width": 20,
+      "height": 50,
+      "isEnabled": true,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "org1' > 0"
+    },
+    {
+      "id": "bed2",
+      "position": {
+        "x": -300,
+        "y": -350
+      },
+      "label": "bed status",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "org2' > 0"
+    },
+    {
+      "id": "eom1",
+      "position": {
+        "x": -100,
+        "y": -350
+      },
+      "label": "Eom",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "roomTransfer' = true"
+    },
+    {
+      "id": "eom2",
+      "position": {
+        "x": 100,
+        "y": -350
+      },
+      "label": "Eom",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "roomTransfer' = true"
+    },
+    {
+      "id": "tra1",
+      "position": {
+        "x": 300,
+        "y": -350
+      },
+      "label": "Transfer",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "org1 distinct 207",
+      "postcondition": ""
+    },
+    {
+      "id": "tra2",
+      "position": {
+        "x": 500,
+        "y": -350
+      },
+      "label": "Transfer",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "org1 distinct 207",
+      "postcondition": ""
+    }
+  ],
+  "arcs": [
+    {
+      "id": "252bb7b2-6fce-42a3-bd35-359f046403c7",
+      "source": "start",
+      "target": "bed1",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "facafde5-87a1-492b-b6e7-21ecf3c859f0",
+      "source": "bed1",
+      "target": "p1",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "2df0fbbb-0499-47aa-8792-b81a38675f37",
+      "source": "p1",
+      "target": "bed2",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "f33c1710-04f7-4bdf-b0a2-cd5bace9ac0f",
+      "source": "bed2",
+      "target": "p2",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "2f799c40-357b-4cc5-bbb6-4819c1fe0f92",
+      "source": "p2",
+      "target": "eom1",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a13af8a1-817d-4e9e-bcaf-b1e6f09bdf5c",
+      "source": "eom1",
+      "target": "p3",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "0a544666-1a54-4fde-afdd-1499fbd04ec6",
+      "source": "p3",
+      "target": "eom2",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "698214a5-bc8f-478a-9ac7-61d210f36a40",
+      "source": "eom2",
+      "target": "p4",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "093a9fef-61aa-44f8-ae27-14689b246c16",
+      "source": "p4",
+      "target": "tra1",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "162d2464-c1a5-4ef2-80e1-a69ce26e9257",
+      "source": "tra1",
+      "target": "p5",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "5e8e1eee-2abd-43d9-b843-3f72dc65f058",
+      "source": "p5",
+      "target": "tra2",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "bcb75f6d-81b9-44e8-b54d-e0a65ded2872",
+      "source": "tra2",
+      "target": "end",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    }
+  ],
+  "dataVariables": [
+    {
+      "id": "da368d15-8108-4867-9e5f-5be16716ceb2",
+      "name": "org1",
+      "type": "int",
+      "currentValue": 1,
+      "description": ""
+    },
+    {
+      "id": "e161c7b3-e5d8-4a44-aec6-981c51e8f7d6",
+      "name": "org2",
+      "type": "int",
+      "currentValue": 1,
+      "description": ""
+    },
+    {
+      "id": "16b8727b-5877-4b4d-9605-4f110cfa28a9",
+      "name": "roomTransfer",
+      "type": "bool",
+      "currentValue": true,
+      "description": ""
+    }
+  ]
+}

--- a/public/examples/auction-process-dpn.json
+++ b/public/examples/auction-process-dpn.json
@@ -1,254 +1,254 @@
 {
-    "id": "auction-process-dpn",
-    "name": "Simple Auction Process Data Petri Net",
-    "description": "A Data Petri Net representing a simple auction process as shown in Example 1. The last offer is stored in 'o' and time progression is captured by 't'.",
-    "places": [
-      {
-        "id": "p0",
-        "position": {
-          "x": 330,
-          "y": 10
-        },
-        "label": "p₀",
-        "tokens": 1,
-        "capacity": null,
-        "radius": 20
+  "id": "auction-process-dpn",
+  "name": "Simple Auction Process Data Petri Net",
+  "description": "A Data Petri Net representing a simple auction process as shown in Example 1. The last offer is stored in 'o' and time progression is captured by 't'.",
+  "places": [
+    {
+      "id": "p0",
+      "position": {
+        "x": 330,
+        "y": 10
       },
-      {
-        "id": "p1",
-        "position": {
-          "x": 250,
-          "y": 240
-        },
-        "label": "p₁",
-        "tokens": 0,
-        "capacity": null,
-        "radius": 20
+      "label": "p₀",
+      "tokens": 1,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "p1",
+      "position": {
+        "x": 250,
+        "y": 240
       },
-      {
-        "id": "p2",
-        "position": {
-          "x": 400,
-          "y": 240
-        },
-        "label": "p₂",
-        "tokens": 0,
-        "capacity": null,
-        "radius": 20
+      "label": "p₁",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "p2",
+      "position": {
+        "x": 400,
+        "y": 240
       },
-      {
-        "id": "p3",
-        "position": {
-          "x": 330,
-          "y": 480
-        },
-        "label": "p₃",
-        "tokens": 0,
-        "capacity": null,
-        "radius": 20
-      }
-    ],
-    "transitions": [
-      {
-        "id": "init",
-        "position": {
-          "x": 330,
-          "y": 160
-        },
-        "label": "init",
-        "width": 20,
-        "height": 50,
-        "isEnabled": true,
-        "priority": 1,
-        "delay": 0,
-        "precondition": "",
-        "postcondition": "t' = t + 1; o' = 0;"
+      "label": "p₂",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "p3",
+      "position": {
+        "x": 330,
+        "y": 480
       },
-      {
-        "id": "bid",
-        "position": {
-          "x": 140,
-          "y": 240
-        },
-        "label": "bid",
-        "width": 20,
-        "height": 50,
-        "isEnabled": false,
-        "priority": 1,
-        "delay": 0,
-        "precondition": "t > 0",
-        "postcondition": "o' = o + 5;"
+      "label": "p₃",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    }
+  ],
+  "transitions": [
+    {
+      "id": "init",
+      "position": {
+        "x": 330,
+        "y": 160
       },
-      {
-        "id": "hammer",
-        "position": {
-          "x": 330,
-          "y": 310
-        },
-        "label": "hammer",
-        "width": 20,
-        "height": 50,
-        "isEnabled": false,
-        "priority": 1,
-        "delay": 0,
-        "precondition": "t <= 0 && o > 0",
-        "postcondition": ""
+      "label": "init",
+      "width": 20,
+      "height": 50,
+      "isEnabled": true,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "t' = t + 1 and o' = 0"
+    },
+    {
+      "id": "bid",
+      "position": {
+        "x": 140,
+        "y": 240
       },
-      {
-        "id": "timer",
-        "position": {
-          "x": 510,
-          "y": 240
-        },
-        "label": "timer",
-        "width": 20,
-        "height": 50,
-        "isEnabled": false,
-        "priority": 1,
-        "delay": 0,
-        "precondition": "t > 0",
-        "postcondition": "t' = t + 1;"
+      "label": "bid",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "t > 0",
+      "postcondition": "o' = o + 5"
+    },
+    {
+      "id": "hammer",
+      "position": {
+        "x": 330,
+        "y": 310
       },
-      {
-        "id": "reset",
-        "position": {
-          "x": 590,
-          "y": 240
-        },
-        "label": "reset",
-        "width": 20,
-        "height": 50,
-        "isEnabled": false,
-        "priority": 1,
-        "delay": 0,
-        "precondition": "o == 0",
-        "postcondition": ""
-      }
-    ],
-    "arcs": [
-      {
-        "id": "a1",
-        "source": "p0",
-        "target": "init",
-        "weight": 1,
-        "type": "regular",
-        "points": [],
-        "label": "1"
+      "label": "hammer",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "t <= 0 and o > 0",
+      "postcondition": ""
+    },
+    {
+      "id": "timer",
+      "position": {
+        "x": 510,
+        "y": 240
       },
-      {
-        "id": "a4",
-        "source": "init",
-        "target": "p2",
-        "weight": 1,
-        "type": "regular",
-        "points": [],
-        "label": "1"
+      "label": "timer",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "t > 0",
+      "postcondition": "t' = t + 1"
+    },
+    {
+      "id": "reset",
+      "position": {
+        "x": 590,
+        "y": 240
       },
-      {
-        "id": "a7",
-        "source": "p2",
-        "target": "timer",
-        "weight": 1,
-        "type": "regular",
-        "points": [],
-        "label": "1"
-      },
-      {
-        "id": "a8",
-        "source": "timer",
-        "target": "p2",
-        "weight": 1,
-        "type": "regular",
-        "points": [],
-        "label": "1"
-      },
-      {
-        "id": "a9",
-        "source": "p2",
-        "target": "hammer",
-        "weight": 1,
-        "type": "regular",
-        "points": [],
-        "label": "1"
-      },
-      {
-        "id": "a10",
-        "source": "hammer",
-        "target": "p3",
-        "weight": 1,
-        "type": "regular",
-        "points": [],
-        "label": "1"
-      },
-      {
-        "id": "a12",
-        "source": "reset",
-        "target": "p0",
-        "weight": 1,
-        "type": "regular",
-        "points": [],
-        "label": "1"
-      },
-      {
-        "id": "9895fd3d-20ff-4c14-a24e-ee7ea8918a32",
-        "source": "init",
-        "target": "p1",
-        "weight": 1,
-        "type": "regular",
-        "points": [],
-        "label": "1"
-      },
-      {
-        "id": "83665ab2-352a-4889-96cf-b973cdc69ccb",
-        "source": "p1",
-        "target": "bid",
-        "weight": 1,
-        "type": "regular",
-        "points": [],
-        "label": "1"
-      },
-      {
-        "id": "b1dd3d84-f9d8-4d8f-b277-04faa78d29c5",
-        "source": "bid",
-        "target": "p1",
-        "weight": 1,
-        "type": "regular",
-        "points": [],
-        "label": "1"
-      },
-      {
-        "id": "117ad2fa-5042-4d4f-8efc-c5d7940326ce",
-        "source": "p1",
-        "target": "hammer",
-        "weight": 1,
-        "type": "regular",
-        "points": [],
-        "label": "1"
-      },
-      {
-        "id": "b4a0d4d0-6f3b-4d43-8b86-b8696100b90c",
-        "source": "p3",
-        "target": "reset",
-        "weight": 1,
-        "type": "regular",
-        "points": [],
-        "label": "1"
-      }
-    ],
-    "dataVariables": [
-      {
-        "id": "var1",
-        "name": "o",
-        "type": "number",
-        "currentValue": 0,
-        "description": "Last offer in the auction"
-      },
-      {
-        "id": "var2",
-        "name": "t",
-        "type": "number",
-        "currentValue": 0,
-        "description": "Time progression (countdown timer)"
-      }
-    ]
-  }
+      "label": "reset",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "o = 0",
+      "postcondition": ""
+    }
+  ],
+  "arcs": [
+    {
+      "id": "a1",
+      "source": "p0",
+      "target": "init",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a4",
+      "source": "init",
+      "target": "p2",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a7",
+      "source": "p2",
+      "target": "timer",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a8",
+      "source": "timer",
+      "target": "p2",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a9",
+      "source": "p2",
+      "target": "hammer",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a10",
+      "source": "hammer",
+      "target": "p3",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a12",
+      "source": "reset",
+      "target": "p0",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "9895fd3d-20ff-4c14-a24e-ee7ea8918a32",
+      "source": "init",
+      "target": "p1",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "83665ab2-352a-4889-96cf-b973cdc69ccb",
+      "source": "p1",
+      "target": "bid",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "b1dd3d84-f9d8-4d8f-b277-04faa78d29c5",
+      "source": "bid",
+      "target": "p1",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "117ad2fa-5042-4d4f-8efc-c5d7940326ce",
+      "source": "p1",
+      "target": "hammer",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "b4a0d4d0-6f3b-4d43-8b86-b8696100b90c",
+      "source": "p3",
+      "target": "reset",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    }
+  ],
+  "dataVariables": [
+    {
+      "id": "var1",
+      "name": "o",
+      "type": "real",
+      "currentValue": 0,
+      "description": "Last offer in the auction"
+    },
+    {
+      "id": "var2",
+      "name": "t",
+      "type": "real",
+      "currentValue": 0,
+      "description": "Time progression (countdown timer)"
+    }
+  ]
+}

--- a/public/examples/p1_violation_deadlock.json
+++ b/public/examples/p1_violation_deadlock.json
@@ -1,1 +1,311 @@
-{"id":"net-001","name":"Sample Net","description":"Converted from old schema","places":[{"id":"p_start","position":{"x":-600,"y":-140},"label":"Start","tokens":1,"capacity":null,"finalMarking":null,"radius":20},{"id":"p_choice","position":{"x":-350,"y":-140},"label":"Choice","tokens":0,"capacity":null,"finalMarking":null,"radius":20},{"id":"p_branch_a","position":{"x":-130,"y":-240},"label":"Branch A","tokens":0,"capacity":null,"finalMarking":null,"radius":20},{"id":"p_branch_b","position":{"x":-130,"y":-50},"label":"Branch B","tokens":0,"capacity":null,"finalMarking":null,"radius":20},{"id":"p_merge","position":{"x":90,"y":-240},"label":"Merge1","tokens":0,"capacity":null,"finalMarking":null,"radius":20},{"id":"p_end","position":{"x":320,"y":-140},"label":"End","tokens":0,"capacity":null,"finalMarking":1,"radius":20},{"id":"f75dbbd0-9c6d-48e4-adaa-dcb2c45db529","position":{"x":90,"y":-50},"label":"Merge2","tokens":0,"capacity":null,"finalMarking":null,"radius":20}],"transitions":[{"id":"t_init","position":{"x":-460,"y":-140},"label":"Initialize","width":20,"height":50,"isEnabled":true,"priority":0,"delay":0,"precondition":"","postcondition":"x' = 0"},{"id":"t_decide_a","position":{"x":-240,"y":-240},"label":"Go to A","width":20,"height":50,"isEnabled":false,"priority":0,"delay":0,"precondition":"x == 0","postcondition":""},{"id":"t_decide_b","position":{"x":-240,"y":-50},"label":"Go to B","width":20,"height":50,"isEnabled":false,"priority":0,"delay":0,"precondition":"x == 1","postcondition":""},{"id":"t_task_a","position":{"x":-10,"y":-240},"label":"Task A","width":20,"height":50,"isEnabled":false,"priority":0,"delay":0,"precondition":"","postcondition":""},{"id":"t_task_b","position":{"x":-10,"y":-50},"label":"Task B","width":20,"height":50,"isEnabled":false,"priority":0,"delay":0,"precondition":"","postcondition":""},{"id":"t_join","position":{"x":220,"y":-140},"label":"Join","width":20,"height":50,"isEnabled":false,"priority":0,"delay":0,"precondition":"","postcondition":""}],"arcs":[{"id":"a5","source":"t_decide_a","target":"p_branch_a","weight":1,"type":"normal","points":[],"label":"1"},{"id":"a6","source":"t_decide_b","target":"p_branch_b","weight":1,"type":"normal","points":[],"label":"1"},{"id":"d3c0a9e9-fb7d-4465-ba92-3ae5e96b1a2d","source":"p_start","target":"t_init","weight":1,"type":"regular","points":[],"label":"1"},{"id":"29d5e7fc-6c2b-450a-9546-9b84cbc66b6a","source":"t_init","target":"p_choice","weight":1,"type":"regular","points":[],"label":"1"},{"id":"e29f078d-2869-40f8-8b4f-a3d43da60cf9","source":"p_choice","target":"t_decide_a","weight":1,"type":"regular","points":[],"label":"1"},{"id":"da2dafba-1194-4ef0-b52f-a20a7a74acf7","source":"p_choice","target":"t_decide_b","weight":1,"type":"regular","points":[],"label":"1"},{"id":"d1ef7ae2-ed0d-42ef-9463-2fb7388c7bb3","source":"t_task_a","target":"p_merge","weight":1,"type":"regular","points":[],"label":"1"},{"id":"753cc1bd-e7d0-4ccb-aa69-58468c7d1735","source":"p_merge","target":"t_join","weight":1,"type":"regular","points":[],"label":"1"},{"id":"d6116885-e151-42ce-9b6d-5506e32c70e8","source":"t_join","target":"p_end","weight":1,"type":"regular","points":[],"label":"1"},{"id":"9b72cb42-e759-48a2-8113-21db84320402","source":"p_branch_a","target":"t_task_a","weight":1,"type":"regular","points":[],"label":"1"},{"id":"1428775a-3f47-4849-8d3e-5ac554c0202b","source":"p_branch_b","target":"t_task_b","weight":1,"type":"regular","points":[],"label":"1"},{"id":"acde1c83-e808-417c-9e85-6168f6fe6d8a","source":"t_task_b","target":"f75dbbd0-9c6d-48e4-adaa-dcb2c45db529","weight":1,"type":"regular","points":[],"label":"1"},{"id":"b66b3f6a-510e-413f-a3bb-aae39f78d12a","source":"f75dbbd0-9c6d-48e4-adaa-dcb2c45db529","target":"t_join","weight":1,"type":"regular","points":[],"label":"1"}],"dataVariables":[{"id":"var_x","name":"x","type":"int","currentValue":0,"description":""}]}
+{
+  "id": "net-001",
+  "name": "Sample Net",
+  "description": "Converted from old schema",
+  "places": [
+    {
+      "id": "p_start",
+      "position": {
+        "x": -600,
+        "y": -140
+      },
+      "label": "Start",
+      "tokens": 1,
+      "capacity": null,
+      "finalMarking": null,
+      "radius": 20
+    },
+    {
+      "id": "p_choice",
+      "position": {
+        "x": -350,
+        "y": -140
+      },
+      "label": "Choice",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": null,
+      "radius": 20
+    },
+    {
+      "id": "p_branch_a",
+      "position": {
+        "x": -130,
+        "y": -240
+      },
+      "label": "Branch A",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": null,
+      "radius": 20
+    },
+    {
+      "id": "p_branch_b",
+      "position": {
+        "x": -130,
+        "y": -50
+      },
+      "label": "Branch B",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": null,
+      "radius": 20
+    },
+    {
+      "id": "p_merge",
+      "position": {
+        "x": 90,
+        "y": -240
+      },
+      "label": "Merge1",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": null,
+      "radius": 20
+    },
+    {
+      "id": "p_end",
+      "position": {
+        "x": 320,
+        "y": -140
+      },
+      "label": "End",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 1,
+      "radius": 20
+    },
+    {
+      "id": "f75dbbd0-9c6d-48e4-adaa-dcb2c45db529",
+      "position": {
+        "x": 90,
+        "y": -50
+      },
+      "label": "Merge2",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": null,
+      "radius": 20
+    }
+  ],
+  "transitions": [
+    {
+      "id": "t_init",
+      "position": {
+        "x": -460,
+        "y": -140
+      },
+      "label": "Initialize",
+      "width": 20,
+      "height": 50,
+      "isEnabled": true,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "x' = 0"
+    },
+    {
+      "id": "t_decide_a",
+      "position": {
+        "x": -240,
+        "y": -240
+      },
+      "label": "Go to A",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "x = 0",
+      "postcondition": ""
+    },
+    {
+      "id": "t_decide_b",
+      "position": {
+        "x": -240,
+        "y": -50
+      },
+      "label": "Go to B",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "x = 1",
+      "postcondition": ""
+    },
+    {
+      "id": "t_task_a",
+      "position": {
+        "x": -10,
+        "y": -240
+      },
+      "label": "Task A",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": ""
+    },
+    {
+      "id": "t_task_b",
+      "position": {
+        "x": -10,
+        "y": -50
+      },
+      "label": "Task B",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": ""
+    },
+    {
+      "id": "t_join",
+      "position": {
+        "x": 220,
+        "y": -140
+      },
+      "label": "Join",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": ""
+    }
+  ],
+  "arcs": [
+    {
+      "id": "a5",
+      "source": "t_decide_a",
+      "target": "p_branch_a",
+      "weight": 1,
+      "type": "normal",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a6",
+      "source": "t_decide_b",
+      "target": "p_branch_b",
+      "weight": 1,
+      "type": "normal",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "d3c0a9e9-fb7d-4465-ba92-3ae5e96b1a2d",
+      "source": "p_start",
+      "target": "t_init",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "29d5e7fc-6c2b-450a-9546-9b84cbc66b6a",
+      "source": "t_init",
+      "target": "p_choice",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "e29f078d-2869-40f8-8b4f-a3d43da60cf9",
+      "source": "p_choice",
+      "target": "t_decide_a",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "da2dafba-1194-4ef0-b52f-a20a7a74acf7",
+      "source": "p_choice",
+      "target": "t_decide_b",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "d1ef7ae2-ed0d-42ef-9463-2fb7388c7bb3",
+      "source": "t_task_a",
+      "target": "p_merge",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "753cc1bd-e7d0-4ccb-aa69-58468c7d1735",
+      "source": "p_merge",
+      "target": "t_join",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "d6116885-e151-42ce-9b6d-5506e32c70e8",
+      "source": "t_join",
+      "target": "p_end",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "9b72cb42-e759-48a2-8113-21db84320402",
+      "source": "p_branch_a",
+      "target": "t_task_a",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "1428775a-3f47-4849-8d3e-5ac554c0202b",
+      "source": "p_branch_b",
+      "target": "t_task_b",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "acde1c83-e808-417c-9e85-6168f6fe6d8a",
+      "source": "t_task_b",
+      "target": "f75dbbd0-9c6d-48e4-adaa-dcb2c45db529",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "b66b3f6a-510e-413f-a3bb-aae39f78d12a",
+      "source": "f75dbbd0-9c6d-48e4-adaa-dcb2c45db529",
+      "target": "t_join",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    }
+  ],
+  "dataVariables": [
+    {
+      "id": "var_x",
+      "name": "x",
+      "type": "int",
+      "currentValue": 0,
+      "description": ""
+    }
+  ]
+}

--- a/public/examples/p3_violation_dead_transition.json
+++ b/public/examples/p3_violation_dead_transition.json
@@ -1,1 +1,164 @@
-{"id":"net-001","name":"Sample Net","description":"Converted from old schema","places":[{"id":"p_start","position":{"x":-210,"y":70},"label":"Start","tokens":1,"capacity":null,"finalMarking":null,"radius":20},{"id":"p_waiting","position":{"x":150,"y":70},"label":"Waiting for Action","tokens":0,"capacity":null,"finalMarking":null,"radius":20},{"id":"p_end","position":{"x":490,"y":60},"label":"End","tokens":0,"capacity":null,"finalMarking":1,"radius":20}],"transitions":[{"id":"t_init_session","position":{"x":-40,"y":70},"label":"Initialize Session","width":20,"height":50,"isEnabled":true,"priority":0,"delay":0,"precondition":"","postcondition":"role' = 0"},{"id":"t_regular_action","position":{"x":310,"y":180},"label":"Regular Action","width":20,"height":50,"isEnabled":false,"priority":0,"delay":0,"precondition":"role == 2","postcondition":""},{"id":"t_admin_override","position":{"x":300,"y":-50},"label":"Admin Override","width":20,"height":50,"isEnabled":false,"priority":0,"delay":0,"precondition":"role == 1","postcondition":""}],"arcs":[{"id":"a4","source":"p_regular_action","target":"p_end","weight":1,"type":"normal","points":[],"label":"1"},{"id":"c06f1c0c-c7e2-4d3f-b8cf-cc3734f43ef8","source":"p_start","target":"t_init_session","weight":1,"type":"regular","points":[],"label":"1"},{"id":"67619bb0-6e33-4bf8-91bf-ff7cb1d4e8f0","source":"t_init_session","target":"p_waiting","weight":1,"type":"regular","points":[],"label":"1"},{"id":"bef3b0b4-c95f-4c7f-b987-5c36c0208655","source":"p_waiting","target":"t_admin_override","weight":1,"type":"regular","points":[],"label":"1"},{"id":"7536cacc-a734-4d0c-9aad-8b50c06dd4b8","source":"p_waiting","target":"t_regular_action","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a3c86412-9a1e-40eb-997b-343552eaee2a","source":"t_regular_action","target":"p_end","weight":1,"type":"regular","points":[],"label":"1"},{"id":"3e1d2713-a20b-4213-aac2-b5e504da507a","source":"t_admin_override","target":"p_end","weight":1,"type":"regular","points":[],"label":"1"}],"dataVariables":[{"id":"var_role","name":"role","type":"int","currentValue":0,"description":""}]}
+{
+  "id": "net-001",
+  "name": "Sample Net",
+  "description": "Converted from old schema",
+  "places": [
+    {
+      "id": "p_start",
+      "position": {
+        "x": -210,
+        "y": 70
+      },
+      "label": "Start",
+      "tokens": 1,
+      "capacity": null,
+      "finalMarking": null,
+      "radius": 20
+    },
+    {
+      "id": "p_waiting",
+      "position": {
+        "x": 150,
+        "y": 70
+      },
+      "label": "Waiting for Action",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": null,
+      "radius": 20
+    },
+    {
+      "id": "p_end",
+      "position": {
+        "x": 490,
+        "y": 60
+      },
+      "label": "End",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 1,
+      "radius": 20
+    }
+  ],
+  "transitions": [
+    {
+      "id": "t_init_session",
+      "position": {
+        "x": -40,
+        "y": 70
+      },
+      "label": "Initialize Session",
+      "width": 20,
+      "height": 50,
+      "isEnabled": true,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "role' = 0"
+    },
+    {
+      "id": "t_regular_action",
+      "position": {
+        "x": 310,
+        "y": 180
+      },
+      "label": "Regular Action",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "role = 2",
+      "postcondition": ""
+    },
+    {
+      "id": "t_admin_override",
+      "position": {
+        "x": 300,
+        "y": -50
+      },
+      "label": "Admin Override",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "role = 1",
+      "postcondition": ""
+    }
+  ],
+  "arcs": [
+    {
+      "id": "a4",
+      "source": "p_regular_action",
+      "target": "p_end",
+      "weight": 1,
+      "type": "normal",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "c06f1c0c-c7e2-4d3f-b8cf-cc3734f43ef8",
+      "source": "p_start",
+      "target": "t_init_session",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "67619bb0-6e33-4bf8-91bf-ff7cb1d4e8f0",
+      "source": "t_init_session",
+      "target": "p_waiting",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "bef3b0b4-c95f-4c7f-b987-5c36c0208655",
+      "source": "p_waiting",
+      "target": "t_admin_override",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "7536cacc-a734-4d0c-9aad-8b50c06dd4b8",
+      "source": "p_waiting",
+      "target": "t_regular_action",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a3c86412-9a1e-40eb-997b-343552eaee2a",
+      "source": "t_regular_action",
+      "target": "p_end",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "3e1d2713-a20b-4213-aac2-b5e504da507a",
+      "source": "t_admin_override",
+      "target": "p_end",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    }
+  ],
+  "dataVariables": [
+    {
+      "id": "var_role",
+      "name": "role",
+      "type": "int",
+      "currentValue": 0,
+      "description": ""
+    }
+  ]
+}

--- a/public/examples/pretty-print-showcase.json
+++ b/public/examples/pretty-print-showcase.json
@@ -4,7 +4,10 @@
   "places": [
     {
       "id": "P_Start",
-      "position": { "x": 100, "y": 50 },
+      "position": {
+        "x": 100,
+        "y": 50
+      },
       "label": "Start",
       "tokens": 1,
       "capacity": null,
@@ -12,7 +15,10 @@
     },
     {
       "id": "P_Comparison",
-      "position": { "x": 300, "y": 50 },
+      "position": {
+        "x": 300,
+        "y": 50
+      },
       "label": "Comparison",
       "tokens": 0,
       "capacity": null,
@@ -20,7 +26,10 @@
     },
     {
       "id": "P_Logical",
-      "position": { "x": 500, "y": 50 },
+      "position": {
+        "x": 500,
+        "y": 50
+      },
       "label": "Logical",
       "tokens": 0,
       "capacity": null,
@@ -28,7 +37,10 @@
     },
     {
       "id": "P_Arithmetic",
-      "position": { "x": 700, "y": 50 },
+      "position": {
+        "x": 700,
+        "y": 50
+      },
       "label": "Arithmetic",
       "tokens": 0,
       "capacity": null,
@@ -36,7 +48,10 @@
     },
     {
       "id": "P_Complex1",
-      "position": { "x": 100, "y": 250 },
+      "position": {
+        "x": 100,
+        "y": 250
+      },
       "label": "Complex1",
       "tokens": 0,
       "capacity": null,
@@ -44,7 +59,10 @@
     },
     {
       "id": "P_Complex2",
-      "position": { "x": 300, "y": 250 },
+      "position": {
+        "x": 300,
+        "y": 250
+      },
       "label": "Complex2",
       "tokens": 0,
       "capacity": null,
@@ -52,7 +70,10 @@
     },
     {
       "id": "P_Mixed",
-      "position": { "x": 500, "y": 250 },
+      "position": {
+        "x": 500,
+        "y": 250
+      },
       "label": "Mixed",
       "tokens": 0,
       "capacity": null,
@@ -60,7 +81,10 @@
     },
     {
       "id": "P_Advanced",
-      "position": { "x": 700, "y": 250 },
+      "position": {
+        "x": 700,
+        "y": 250
+      },
       "label": "Advanced",
       "tokens": 0,
       "capacity": null,
@@ -68,7 +92,10 @@
     },
     {
       "id": "P_Primed",
-      "position": { "x": 100, "y": 450 },
+      "position": {
+        "x": 100,
+        "y": 450
+      },
       "label": "Primed Vars",
       "tokens": 0,
       "capacity": null,
@@ -76,7 +103,10 @@
     },
     {
       "id": "P_Nested",
-      "position": { "x": 300, "y": 450 },
+      "position": {
+        "x": 300,
+        "y": 450
+      },
       "label": "Nested",
       "tokens": 0,
       "capacity": null,
@@ -84,7 +114,10 @@
     },
     {
       "id": "P_Boolean",
-      "position": { "x": 500, "y": 450 },
+      "position": {
+        "x": 500,
+        "y": 450
+      },
       "label": "Boolean",
       "tokens": 0,
       "capacity": null,
@@ -92,7 +125,10 @@
     },
     {
       "id": "P_End",
-      "position": { "x": 700, "y": 450 },
+      "position": {
+        "x": 700,
+        "y": 450
+      },
       "label": "End",
       "tokens": 0,
       "capacity": null,
@@ -102,7 +138,10 @@
   "transitions": [
     {
       "id": "T_GreaterEqual",
-      "position": { "x": 200, "y": 50 },
+      "position": {
+        "x": 200,
+        "y": 50
+      },
       "label": "T_GreaterEqual",
       "width": 20,
       "height": 50,
@@ -114,7 +153,10 @@
     },
     {
       "id": "T_LessEqual",
-      "position": { "x": 400, "y": 50 },
+      "position": {
+        "x": 400,
+        "y": 50
+      },
       "label": "T_LessEqual",
       "width": 20,
       "height": 50,
@@ -126,43 +168,55 @@
     },
     {
       "id": "T_NotEqual",
-      "position": { "x": 600, "y": 50 },
+      "position": {
+        "x": 600,
+        "y": 50
+      },
       "label": "T_NotEqual",
       "width": 20,
       "height": 50,
       "isEnabled": false,
       "priority": 1,
       "delay": 0,
-      "precondition": "value != 0",
+      "precondition": "value distinct 0",
       "postcondition": "status' = 1"
     },
     {
       "id": "T_And",
-      "position": { "x": 800, "y": 50 },
+      "position": {
+        "x": 800,
+        "y": 50
+      },
       "label": "T_And",
       "width": 20,
       "height": 50,
       "isEnabled": false,
       "priority": 1,
       "delay": 0,
-      "precondition": "x >= 5 && y <= 20",
+      "precondition": "x >= 5 and y <= 20",
       "postcondition": "flag' = true"
     },
     {
       "id": "T_Or",
-      "position": { "x": 200, "y": 250 },
+      "position": {
+        "x": 200,
+        "y": 250
+      },
       "label": "T_Or",
       "width": 20,
       "height": 50,
       "isEnabled": false,
       "priority": 1,
       "delay": 0,
-      "precondition": "a == 0 || b != 0",
+      "precondition": "a = 0 or b distinct 0",
       "postcondition": "choice' = a"
     },
     {
       "id": "T_Multiply",
-      "position": { "x": 400, "y": 250 },
+      "position": {
+        "x": 400,
+        "y": 250
+      },
       "label": "T_Multiply",
       "width": 20,
       "height": 50,
@@ -174,75 +228,93 @@
     },
     {
       "id": "T_ComplexAnd",
-      "position": { "x": 600, "y": 250 },
+      "position": {
+        "x": 600,
+        "y": 250
+      },
       "label": "T_ComplexAnd",
       "width": 20,
       "height": 50,
       "isEnabled": false,
       "priority": 1,
       "delay": 0,
-      "precondition": "x >= min && x <= max && active == true",
+      "precondition": "x >= min and x <= max and active = true",
       "postcondition": "validated' = x"
     },
     {
       "id": "T_ComplexOr",
-      "position": { "x": 800, "y": 250 },
+      "position": {
+        "x": 800,
+        "y": 250
+      },
       "label": "T_ComplexOr",
       "width": 20,
       "height": 50,
       "isEnabled": false,
       "priority": 1,
       "delay": 0,
-      "precondition": "error != 0 || timeout >= 100 || cancelled == true",
+      "precondition": "error distinct 0 or timeout >= 100 or cancelled = true",
       "postcondition": "state' = 99"
     },
     {
       "id": "T_MultiPrimed",
-      "position": { "x": 200, "y": 450 },
+      "position": {
+        "x": 200,
+        "y": 450
+      },
       "label": "T_MultiPrimed",
       "width": 20,
       "height": 50,
       "isEnabled": false,
       "priority": 1,
       "delay": 0,
-      "precondition": "x' >= x + 1 && y' <= y * 2",
-      "postcondition": "x' = x + 1; y' = y * 2; z' = x * y"
+      "precondition": "x' >= x + 1 and y' <= y * 2",
+      "postcondition": "x' = x + 1 and y' = y * 2 and z' = x * y"
     },
     {
       "id": "T_NestedLogic",
-      "position": { "x": 400, "y": 450 },
+      "position": {
+        "x": 400,
+        "y": 450
+      },
       "label": "T_NestedLogic",
       "width": 20,
       "height": 50,
       "isEnabled": false,
       "priority": 1,
       "delay": 0,
-      "precondition": "(a >= 10 && b <= 50) || (c != 0 && d == 1)",
+      "precondition": "(a >= 10 and b <= 50) or (c distinct 0 and d = 1)",
       "postcondition": "output' = a + b * c"
     },
     {
       "id": "T_BooleanOps",
-      "position": { "x": 600, "y": 450 },
+      "position": {
+        "x": 600,
+        "y": 450
+      },
       "label": "T_BooleanOps",
       "width": 20,
       "height": 50,
       "isEnabled": false,
       "priority": 1,
       "delay": 0,
-      "precondition": "enabled == true && locked != true",
-      "postcondition": "ready' = true; active' = false"
+      "precondition": "enabled = true and locked distinct true",
+      "postcondition": "ready' = true and active' = false"
     },
     {
       "id": "T_AllOperators",
-      "position": { "x": 800, "y": 450 },
+      "position": {
+        "x": 800,
+        "y": 450
+      },
       "label": "T_AllOperators",
       "width": 20,
       "height": 50,
       "isEnabled": false,
       "priority": 1,
       "delay": 0,
-      "precondition": "x >= 0 && y <= 100 && z != 50 && w == 25",
-      "postcondition": "result' = x + y * z; final' = result >= threshold"
+      "precondition": "x >= 0 and y <= 100 and z distinct 50 and w = 25",
+      "postcondition": "result' = x + y * z and final' = result >= threshold"
     }
   ],
   "arcs": [
@@ -315,8 +387,7 @@
       "target": "P_Complex1",
       "weight": 1,
       "type": "regular",
-      "points": [
-      ],
+      "points": [],
       "label": "1"
     },
     {
@@ -388,8 +459,7 @@
       "target": "P_Primed",
       "weight": 1,
       "type": "regular",
-      "points": [
-      ],
+      "points": [],
       "label": "1"
     },
     {
@@ -460,224 +530,224 @@
     {
       "id": "var_x",
       "name": "x",
-      "type": "number",
+      "type": "real",
       "currentValue": 15,
       "description": "Test variable for >= operator"
     },
     {
       "id": "var_y",
       "name": "y",
-      "type": "number",
+      "type": "real",
       "currentValue": 50,
       "description": "Test variable for <= operator"
     },
     {
       "id": "var_z",
       "name": "z",
-      "type": "number",
+      "type": "real",
       "currentValue": 75,
       "description": "Test variable for complex expressions"
     },
     {
       "id": "var_w",
       "name": "w",
-      "type": "number",
+      "type": "real",
       "currentValue": 25,
       "description": "Test variable for == operator"
     },
     {
       "id": "var_value",
       "name": "value",
-      "type": "number",
+      "type": "real",
       "currentValue": 5,
       "description": "Test variable for != operator"
     },
     {
       "id": "var_a",
       "name": "a",
-      "type": "number",
+      "type": "real",
       "currentValue": 10,
       "description": "Variable a for complex expressions"
     },
     {
       "id": "var_b",
       "name": "b",
-      "type": "number",
+      "type": "real",
       "currentValue": 20,
       "description": "Variable b for complex expressions"
     },
     {
       "id": "var_c",
       "name": "c",
-      "type": "number",
+      "type": "real",
       "currentValue": 1,
       "description": "Variable c for nested logic"
     },
     {
       "id": "var_d",
       "name": "d",
-      "type": "number",
+      "type": "real",
       "currentValue": 1,
       "description": "Variable d for nested logic"
     },
     {
       "id": "var_counter",
       "name": "counter",
-      "type": "number",
+      "type": "real",
       "currentValue": 0,
       "description": "Counter variable"
     },
     {
       "id": "var_result",
       "name": "result",
-      "type": "number",
+      "type": "real",
       "currentValue": 0,
       "description": "Result variable"
     },
     {
       "id": "var_status",
       "name": "status",
-      "type": "number",
+      "type": "real",
       "currentValue": 0,
       "description": "Status code"
     },
     {
       "id": "var_width",
       "name": "width",
-      "type": "number",
+      "type": "real",
       "currentValue": 10,
       "description": "Width for multiplication example"
     },
     {
       "id": "var_height",
       "name": "height",
-      "type": "number",
+      "type": "real",
       "currentValue": 5,
       "description": "Height for multiplication example"
     },
     {
       "id": "var_area",
       "name": "area",
-      "type": "number",
+      "type": "real",
       "currentValue": 0,
       "description": "Calculated area (width × height)"
     },
     {
       "id": "var_min",
       "name": "min",
-      "type": "number",
+      "type": "real",
       "currentValue": 0,
       "description": "Minimum threshold"
     },
     {
       "id": "var_max",
       "name": "max",
-      "type": "number",
+      "type": "real",
       "currentValue": 100,
       "description": "Maximum threshold"
     },
     {
       "id": "var_threshold",
       "name": "threshold",
-      "type": "number",
+      "type": "real",
       "currentValue": 50,
       "description": "Threshold for comparison"
     },
     {
       "id": "var_error",
       "name": "error",
-      "type": "number",
+      "type": "real",
       "currentValue": 0,
       "description": "Error code"
     },
     {
       "id": "var_timeout",
       "name": "timeout",
-      "type": "number",
+      "type": "real",
       "currentValue": 0,
       "description": "Timeout counter"
     },
     {
       "id": "var_count",
       "name": "count",
-      "type": "number",
+      "type": "real",
       "currentValue": 3,
       "description": "Item count"
     },
     {
       "id": "var_choice",
       "name": "choice",
-      "type": "number",
+      "type": "real",
       "currentValue": 0,
       "description": "Choice variable"
     },
     {
       "id": "var_validated",
       "name": "validated",
-      "type": "number",
+      "type": "real",
       "currentValue": 0,
       "description": "Validated value"
     },
     {
       "id": "var_state",
       "name": "state",
-      "type": "number",
+      "type": "real",
       "currentValue": 0,
       "description": "Current state"
     },
     {
       "id": "var_output",
       "name": "output",
-      "type": "number",
+      "type": "real",
       "currentValue": 0,
       "description": "Output value"
     },
     {
       "id": "var_final",
       "name": "final",
-      "type": "boolean",
+      "type": "bool",
       "currentValue": false,
       "description": "Final boolean result"
     },
     {
       "id": "var_flag",
       "name": "flag",
-      "type": "boolean",
+      "type": "bool",
       "currentValue": false,
       "description": "Boolean flag"
     },
     {
       "id": "var_active",
       "name": "active",
-      "type": "boolean",
+      "type": "bool",
       "currentValue": true,
       "description": "Active status"
     },
     {
       "id": "var_enabled",
       "name": "enabled",
-      "type": "boolean",
+      "type": "bool",
       "currentValue": true,
       "description": "Enabled status"
     },
     {
       "id": "var_locked",
       "name": "locked",
-      "type": "boolean",
+      "type": "bool",
       "currentValue": false,
       "description": "Locked status"
     },
     {
       "id": "var_ready",
       "name": "ready",
-      "type": "boolean",
+      "type": "bool",
       "currentValue": false,
       "description": "Ready status"
     },
     {
       "id": "var_cancelled",
       "name": "cancelled",
-      "type": "boolean",
+      "type": "bool",
       "currentValue": false,
       "description": "Cancelled flag"
     }

--- a/public/examples/soundness-test-choice-sound.json
+++ b/public/examples/soundness-test-choice-sound.json
@@ -1,1 +1,245 @@
-{"id":"sound-choice","name":"Sound Choice Workflow","description":"Choice workflow with proper guards: both branches lead to end. Sound (passes P1, P2, P3).","places":[{"id":"p_start","position":{"x":100,"y":200},"label":"Start","tokens":1,"capacity":null,"finalMarking":0,"radius":20},{"id":"p_choice","position":{"x":250,"y":200},"label":"Choice","tokens":0,"capacity":null,"finalMarking":0,"radius":20},{"id":"p_branch_a","position":{"x":400,"y":100},"label":"Branch A","tokens":0,"capacity":null,"finalMarking":0,"radius":20},{"id":"p_branch_b","position":{"x":400,"y":300},"label":"Branch B","tokens":0,"capacity":null,"finalMarking":0,"radius":20},{"id":"p_end","position":{"x":550,"y":200},"label":"End","tokens":0,"capacity":null,"finalMarking":1,"radius":20}],"transitions":[{"id":"t_init","position":{"x":175,"y":200},"label":"Init","width":20,"height":50,"isEnabled":true,"priority":0,"delay":0,"precondition":"","postcondition":"choice' >= 0 && choice' <= 1"},{"id":"t_go_a","position":{"x":325,"y":100},"label":"Go A","width":20,"height":50,"isEnabled":false,"priority":0,"delay":0,"precondition":"choice == 0","postcondition":""},{"id":"t_go_b","position":{"x":325,"y":300},"label":"Go B","width":20,"height":50,"isEnabled":false,"priority":0,"delay":0,"precondition":"choice == 1","postcondition":""},{"id":"t_merge_a","position":{"x":475,"y":100},"label":"From A","width":20,"height":50,"isEnabled":false,"priority":0,"delay":0,"precondition":"","postcondition":""},{"id":"t_merge_b","position":{"x":475,"y":300},"label":"From B","width":20,"height":50,"isEnabled":false,"priority":0,"delay":0,"precondition":"","postcondition":""}],"arcs":[{"id":"a1","source":"p_start","target":"t_init","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a2","source":"t_init","target":"p_choice","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a3","source":"p_choice","target":"t_go_a","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a4","source":"p_choice","target":"t_go_b","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a5","source":"t_go_a","target":"p_branch_a","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a6","source":"t_go_b","target":"p_branch_b","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a7","source":"p_branch_a","target":"t_merge_a","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a8","source":"p_branch_b","target":"t_merge_b","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a9","source":"t_merge_a","target":"p_end","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a10","source":"t_merge_b","target":"p_end","weight":1,"type":"regular","points":[],"label":"1"}],"dataVariables":[{"id":"var_choice","name":"choice","type":"int","currentValue":0,"description":"Choice variable"}]}
+{
+  "id": "sound-choice",
+  "name": "Sound Choice Workflow",
+  "description": "Choice workflow with proper guards: both branches lead to end. Sound (passes P1, P2, P3).",
+  "places": [
+    {
+      "id": "p_start",
+      "position": {
+        "x": 100,
+        "y": 200
+      },
+      "label": "Start",
+      "tokens": 1,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_choice",
+      "position": {
+        "x": 250,
+        "y": 200
+      },
+      "label": "Choice",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_branch_a",
+      "position": {
+        "x": 400,
+        "y": 100
+      },
+      "label": "Branch A",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_branch_b",
+      "position": {
+        "x": 400,
+        "y": 300
+      },
+      "label": "Branch B",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_end",
+      "position": {
+        "x": 550,
+        "y": 200
+      },
+      "label": "End",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 1,
+      "radius": 20
+    }
+  ],
+  "transitions": [
+    {
+      "id": "t_init",
+      "position": {
+        "x": 175,
+        "y": 200
+      },
+      "label": "Init",
+      "width": 20,
+      "height": 50,
+      "isEnabled": true,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "choice' >= 0 and choice' <= 1"
+    },
+    {
+      "id": "t_go_a",
+      "position": {
+        "x": 325,
+        "y": 100
+      },
+      "label": "Go A",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "choice = 0",
+      "postcondition": ""
+    },
+    {
+      "id": "t_go_b",
+      "position": {
+        "x": 325,
+        "y": 300
+      },
+      "label": "Go B",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "choice = 1",
+      "postcondition": ""
+    },
+    {
+      "id": "t_merge_a",
+      "position": {
+        "x": 475,
+        "y": 100
+      },
+      "label": "From A",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": ""
+    },
+    {
+      "id": "t_merge_b",
+      "position": {
+        "x": 475,
+        "y": 300
+      },
+      "label": "From B",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": ""
+    }
+  ],
+  "arcs": [
+    {
+      "id": "a1",
+      "source": "p_start",
+      "target": "t_init",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a2",
+      "source": "t_init",
+      "target": "p_choice",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a3",
+      "source": "p_choice",
+      "target": "t_go_a",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a4",
+      "source": "p_choice",
+      "target": "t_go_b",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a5",
+      "source": "t_go_a",
+      "target": "p_branch_a",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a6",
+      "source": "t_go_b",
+      "target": "p_branch_b",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a7",
+      "source": "p_branch_a",
+      "target": "t_merge_a",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a8",
+      "source": "p_branch_b",
+      "target": "t_merge_b",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a9",
+      "source": "t_merge_a",
+      "target": "p_end",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a10",
+      "source": "t_merge_b",
+      "target": "p_end",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    }
+  ],
+  "dataVariables": [
+    {
+      "id": "var_choice",
+      "name": "choice",
+      "type": "int",
+      "currentValue": 0,
+      "description": "Choice variable"
+    }
+  ]
+}

--- a/public/examples/soundness-test-p1-p3-violation-multiple.json
+++ b/public/examples/soundness-test-p1-p3-violation-multiple.json
@@ -1,1 +1,266 @@
-{"id":"p1-p3-violation","name":"P1+P3 Violation: Deadlock and Dead Transition","description":"Violates both P1 (Deadlock) and P3 (Dead Transition): One branch deadlocks, another transition never fires due to impossible guard.","places":[{"id":"p_start","position":{"x":100,"y":200},"label":"Start","tokens":1,"capacity":null,"finalMarking":0,"radius":20},{"id":"p_choice","position":{"x":250,"y":200},"label":"Choice","tokens":0,"capacity":null,"finalMarking":0,"radius":20},{"id":"p_deadlock","position":{"x":400,"y":100},"label":"Deadlock","tokens":0,"capacity":null,"finalMarking":0,"radius":20},{"id":"p_normal","position":{"x":400,"y":200},"label":"Normal","tokens":0,"capacity":null,"finalMarking":0,"radius":20},{"id":"p_dead","position":{"x":400,"y":300},"label":"Dead","tokens":0,"capacity":null,"finalMarking":0,"radius":20},{"id":"p_end","position":{"x":550,"y":200},"label":"End","tokens":0,"capacity":null,"finalMarking":1,"radius":20}],"transitions":[{"id":"t_init","position":{"x":175,"y":200},"label":"Init","width":20,"height":50,"isEnabled":true,"priority":0,"delay":0,"precondition":"","postcondition":"x' >= 0 && x' <= 2"},{"id":"t_deadlock_branch","position":{"x":325,"y":100},"label":"Deadlock","width":20,"height":50,"isEnabled":false,"priority":0,"delay":0,"precondition":"x == 0","postcondition":""},{"id":"t_normal_branch","position":{"x":325,"y":200},"label":"Normal","width":20,"height":50,"isEnabled":false,"priority":0,"delay":0,"precondition":"x == 1","postcondition":""},{"id":"t_dead_branch","position":{"x":325,"y":300},"label":"Dead","width":20,"height":50,"isEnabled":false,"priority":0,"delay":0,"precondition":"x == 2","postcondition":""},{"id":"t_finish","position":{"x":475,"y":200},"label":"Finish","width":20,"height":50,"isEnabled":false,"priority":0,"delay":0,"precondition":"x == 10","postcondition":""}],"arcs":[{"id":"a1","source":"p_start","target":"t_init","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a2","source":"t_init","target":"p_choice","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a3","source":"p_choice","target":"t_deadlock_branch","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a4","source":"p_choice","target":"t_normal_branch","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a5","source":"p_choice","target":"t_dead_branch","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a6","source":"t_deadlock_branch","target":"p_deadlock","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a7","source":"t_normal_branch","target":"p_normal","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a8","source":"t_dead_branch","target":"p_dead","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a9","source":"p_normal","target":"t_finish","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a10","source":"p_dead","target":"t_finish","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a11","source":"t_finish","target":"p_end","weight":1,"type":"regular","points":[],"label":"1"}],"dataVariables":[{"id":"var_x","name":"x","type":"int","currentValue":0,"description":"State variable"}]}
+{
+  "id": "p1-p3-violation",
+  "name": "P1+P3 Violation: Deadlock and Dead Transition",
+  "description": "Violates both P1 (Deadlock) and P3 (Dead Transition): One branch deadlocks, another transition never fires due to impossible guard.",
+  "places": [
+    {
+      "id": "p_start",
+      "position": {
+        "x": 100,
+        "y": 200
+      },
+      "label": "Start",
+      "tokens": 1,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_choice",
+      "position": {
+        "x": 250,
+        "y": 200
+      },
+      "label": "Choice",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_deadlock",
+      "position": {
+        "x": 400,
+        "y": 100
+      },
+      "label": "Deadlock",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_normal",
+      "position": {
+        "x": 400,
+        "y": 200
+      },
+      "label": "Normal",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_dead",
+      "position": {
+        "x": 400,
+        "y": 300
+      },
+      "label": "Dead",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_end",
+      "position": {
+        "x": 550,
+        "y": 200
+      },
+      "label": "End",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 1,
+      "radius": 20
+    }
+  ],
+  "transitions": [
+    {
+      "id": "t_init",
+      "position": {
+        "x": 175,
+        "y": 200
+      },
+      "label": "Init",
+      "width": 20,
+      "height": 50,
+      "isEnabled": true,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "x' >= 0 and x' <= 2"
+    },
+    {
+      "id": "t_deadlock_branch",
+      "position": {
+        "x": 325,
+        "y": 100
+      },
+      "label": "Deadlock",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "x = 0",
+      "postcondition": ""
+    },
+    {
+      "id": "t_normal_branch",
+      "position": {
+        "x": 325,
+        "y": 200
+      },
+      "label": "Normal",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "x = 1",
+      "postcondition": ""
+    },
+    {
+      "id": "t_dead_branch",
+      "position": {
+        "x": 325,
+        "y": 300
+      },
+      "label": "Dead",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "x = 2",
+      "postcondition": ""
+    },
+    {
+      "id": "t_finish",
+      "position": {
+        "x": 475,
+        "y": 200
+      },
+      "label": "Finish",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "x = 10",
+      "postcondition": ""
+    }
+  ],
+  "arcs": [
+    {
+      "id": "a1",
+      "source": "p_start",
+      "target": "t_init",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a2",
+      "source": "t_init",
+      "target": "p_choice",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a3",
+      "source": "p_choice",
+      "target": "t_deadlock_branch",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a4",
+      "source": "p_choice",
+      "target": "t_normal_branch",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a5",
+      "source": "p_choice",
+      "target": "t_dead_branch",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a6",
+      "source": "t_deadlock_branch",
+      "target": "p_deadlock",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a7",
+      "source": "t_normal_branch",
+      "target": "p_normal",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a8",
+      "source": "t_dead_branch",
+      "target": "p_dead",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a9",
+      "source": "p_normal",
+      "target": "t_finish",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a10",
+      "source": "p_dead",
+      "target": "t_finish",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a11",
+      "source": "t_finish",
+      "target": "p_end",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    }
+  ],
+  "dataVariables": [
+    {
+      "id": "var_x",
+      "name": "x",
+      "type": "int",
+      "currentValue": 0,
+      "description": "State variable"
+    }
+  ]
+}

--- a/public/examples/soundness-test-p1-violation-deadlock.json
+++ b/public/examples/soundness-test-p1-violation-deadlock.json
@@ -5,7 +5,10 @@
   "places": [
     {
       "id": "p_start",
-      "position": { "x": 100, "y": 200 },
+      "position": {
+        "x": 100,
+        "y": 200
+      },
       "label": "Start",
       "tokens": 1,
       "capacity": null,
@@ -14,7 +17,10 @@
     },
     {
       "id": "p_choice",
-      "position": { "x": 250, "y": 200 },
+      "position": {
+        "x": 250,
+        "y": 200
+      },
       "label": "Choice",
       "tokens": 0,
       "capacity": null,
@@ -23,7 +29,10 @@
     },
     {
       "id": "p_good",
-      "position": { "x": 400, "y": 100 },
+      "position": {
+        "x": 400,
+        "y": 100
+      },
       "label": "Good Path",
       "tokens": 0,
       "capacity": null,
@@ -32,7 +41,10 @@
     },
     {
       "id": "p_deadlock",
-      "position": { "x": 400, "y": 300 },
+      "position": {
+        "x": 400,
+        "y": 300
+      },
       "label": "Deadlock",
       "tokens": 0,
       "capacity": null,
@@ -41,7 +53,10 @@
     },
     {
       "id": "p_end",
-      "position": { "x": 550, "y": 100 },
+      "position": {
+        "x": 550,
+        "y": 100
+      },
       "label": "End",
       "tokens": 0,
       "capacity": null,
@@ -52,7 +67,10 @@
   "transitions": [
     {
       "id": "t_init",
-      "position": { "x": 175, "y": 200 },
+      "position": {
+        "x": 175,
+        "y": 200
+      },
       "label": "Init",
       "width": 20,
       "height": 50,
@@ -60,35 +78,44 @@
       "priority": 0,
       "delay": 0,
       "precondition": "",
-      "postcondition": "x' >= 0 && x' <= 1"
+      "postcondition": "x' >= 0 and x' <= 1"
     },
     {
       "id": "t_good",
-      "position": { "x": 325, "y": 100 },
+      "position": {
+        "x": 325,
+        "y": 100
+      },
       "label": "Good Branch",
       "width": 20,
       "height": 50,
       "isEnabled": false,
       "priority": 0,
       "delay": 0,
-      "precondition": "x == 1",
+      "precondition": "x = 1",
       "postcondition": ""
     },
     {
       "id": "t_bad",
-      "position": { "x": 325, "y": 300 },
+      "position": {
+        "x": 325,
+        "y": 300
+      },
       "label": "Bad Branch",
       "width": 20,
       "height": 50,
       "isEnabled": false,
       "priority": 0,
       "delay": 0,
-      "precondition": "x == 0",
+      "precondition": "x = 0",
       "postcondition": ""
     },
     {
       "id": "t_finish",
-      "position": { "x": 475, "y": 100 },
+      "position": {
+        "x": 475,
+        "y": 100
+      },
       "label": "Finish",
       "width": 20,
       "height": 50,

--- a/public/examples/soundness-test-p3-violation-dead-transition.json
+++ b/public/examples/soundness-test-p3-violation-dead-transition.json
@@ -1,1 +1,212 @@
-{"id":"p3-dead-transition","name":"P3 Violation: Dead Transition","description":"Violates P3 (No Dead Transitions): Transition 't_never_fires' can never fire due to conflicting data constraints (x == 5 but x is set to 10 and never changes).","places":[{"id":"p_start","position":{"x":100,"y":200},"label":"Start","tokens":1,"capacity":null,"finalMarking":0,"radius":20},{"id":"p_middle","position":{"x":250,"y":200},"label":"Middle","tokens":0,"capacity":null,"finalMarking":0,"radius":20},{"id":"p_branch_a","position":{"x":400,"y":100},"label":"Active Branch","tokens":0,"capacity":null,"finalMarking":0,"radius":20},{"id":"p_branch_b","position":{"x":400,"y":300},"label":"Dead Branch","tokens":0,"capacity":null,"finalMarking":0,"radius":20},{"id":"p_end","position":{"x":550,"y":100},"label":"End","tokens":0,"capacity":null,"finalMarking":1,"radius":20}],"transitions":[{"id":"t_init","position":{"x":175,"y":200},"label":"Init","width":20,"height":50,"isEnabled":true,"priority":0,"delay":0,"precondition":"","postcondition":"x' = 10"},{"id":"t_fires","position":{"x":325,"y":100},"label":"Fires","width":20,"height":50,"isEnabled":false,"priority":0,"delay":0,"precondition":"x == 10","postcondition":""},{"id":"t_never_fires","position":{"x":325,"y":300},"label":"Never Fires","width":20,"height":50,"isEnabled":false,"priority":0,"delay":0,"precondition":"x == 5","postcondition":""},{"id":"t_finish","position":{"x":475,"y":100},"label":"Finish","width":20,"height":50,"isEnabled":false,"priority":0,"delay":0,"precondition":"","postcondition":""}],"arcs":[{"id":"a1","source":"p_start","target":"t_init","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a2","source":"t_init","target":"p_middle","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a3","source":"p_middle","target":"t_fires","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a4","source":"p_middle","target":"t_never_fires","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a5","source":"t_fires","target":"p_branch_a","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a6","source":"t_never_fires","target":"p_branch_b","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a7","source":"p_branch_a","target":"t_finish","weight":1,"type":"regular","points":[],"label":"1"},{"id":"a8","source":"t_finish","target":"p_end","weight":1,"type":"regular","points":[],"label":"1"}],"dataVariables":[{"id":"var_x","name":"x","type":"int","currentValue":0,"description":"State variable"}]}
+{
+  "id": "p3-dead-transition",
+  "name": "P3 Violation: Dead Transition",
+  "description": "Violates P3 (No Dead Transitions): Transition 't_never_fires' can never fire due to conflicting data constraints (x == 5 but x is set to 10 and never changes).",
+  "places": [
+    {
+      "id": "p_start",
+      "position": {
+        "x": 100,
+        "y": 200
+      },
+      "label": "Start",
+      "tokens": 1,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_middle",
+      "position": {
+        "x": 250,
+        "y": 200
+      },
+      "label": "Middle",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_branch_a",
+      "position": {
+        "x": 400,
+        "y": 100
+      },
+      "label": "Active Branch",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_branch_b",
+      "position": {
+        "x": 400,
+        "y": 300
+      },
+      "label": "Dead Branch",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 0,
+      "radius": 20
+    },
+    {
+      "id": "p_end",
+      "position": {
+        "x": 550,
+        "y": 100
+      },
+      "label": "End",
+      "tokens": 0,
+      "capacity": null,
+      "finalMarking": 1,
+      "radius": 20
+    }
+  ],
+  "transitions": [
+    {
+      "id": "t_init",
+      "position": {
+        "x": 175,
+        "y": 200
+      },
+      "label": "Init",
+      "width": 20,
+      "height": 50,
+      "isEnabled": true,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "x' = 10"
+    },
+    {
+      "id": "t_fires",
+      "position": {
+        "x": 325,
+        "y": 100
+      },
+      "label": "Fires",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "x = 10",
+      "postcondition": ""
+    },
+    {
+      "id": "t_never_fires",
+      "position": {
+        "x": 325,
+        "y": 300
+      },
+      "label": "Never Fires",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "x = 5",
+      "postcondition": ""
+    },
+    {
+      "id": "t_finish",
+      "position": {
+        "x": 475,
+        "y": 100
+      },
+      "label": "Finish",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 0,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": ""
+    }
+  ],
+  "arcs": [
+    {
+      "id": "a1",
+      "source": "p_start",
+      "target": "t_init",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a2",
+      "source": "t_init",
+      "target": "p_middle",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a3",
+      "source": "p_middle",
+      "target": "t_fires",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a4",
+      "source": "p_middle",
+      "target": "t_never_fires",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a5",
+      "source": "t_fires",
+      "target": "p_branch_a",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a6",
+      "source": "t_never_fires",
+      "target": "p_branch_b",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a7",
+      "source": "p_branch_a",
+      "target": "t_finish",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "a8",
+      "source": "t_finish",
+      "target": "p_end",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    }
+  ],
+  "dataVariables": [
+    {
+      "id": "var_x",
+      "name": "x",
+      "type": "int",
+      "currentValue": 0,
+      "description": "State variable"
+    }
+  ]
+}

--- a/public/examples/soundness_proba_CF_GUARDS.json
+++ b/public/examples/soundness_proba_CF_GUARDS.json
@@ -1,1 +1,304 @@
-{"id":"35e8b8b7-23c1-4f76-96f1-e5555f3d7874","name":"New Petri Net","description":"","places":[{"id":"7dba29a8-befd-4629-a98a-85f76dac0b7c","position":{"x":210,"y":150},"label":"Start","tokens":1,"capacity":null,"radius":20},{"id":"2a9feebc-2c06-41ca-a8a0-f40c60edd9af","position":{"x":500,"y":150},"label":"P2","tokens":0,"capacity":null,"radius":20},{"id":"3d13bb93-6272-4e81-972c-b88c3d9a82de","position":{"x":780,"y":150},"label":"P3","tokens":0,"capacity":null,"radius":20},{"id":"a3741425-f8c9-496e-a2bf-641a7598879a","position":{"x":620,"y":320},"label":"P4","tokens":0,"capacity":null,"radius":20},{"id":"9f546a8b-c950-42bb-a1a0-f43d821cb6ad","position":{"x":290,"y":320},"label":"P5","tokens":0,"capacity":null,"radius":20},{"id":"cf3080fe-9a2a-4ef0-9667-718904c52896","position":{"x":60,"y":320},"label":"P6","tokens":0,"capacity":null,"radius":20},{"id":"7665ee86-ade0-41e9-8b0c-427f71ac4515","position":{"x":340,"y":450},"label":"P7","tokens":0,"capacity":null,"radius":20}],"transitions":[{"id":"e1abe538-d03c-49aa-8dcd-2573765bfcc0","position":{"x":360,"y":150},"label":"T1","width":20,"height":50,"isEnabled":true,"priority":1,"delay":0,"precondition":"","postcondition":"x' >= 10 && x' <= 1000"},{"id":"269f050e-06ad-4f3f-8204-3cf21dc05317","position":{"x":620,"y":150},"label":"T2","width":20,"height":50,"isEnabled":false,"priority":1,"delay":0,"precondition":"","postcondition":"x' >= 10 && x' <= 1000"},{"id":"90c4c99f-912b-497a-a508-504881694aea","position":{"x":780,"y":310},"label":"T3","width":20,"height":50,"isEnabled":false,"priority":1,"delay":0,"precondition":"","postcondition":"x' >= 10 && x' <= 1000"},{"id":"2429c8d1-2c99-4641-a019-12a42474ab65","position":{"x":430,"y":320},"label":"T4","width":20,"height":50,"isEnabled":false,"priority":1,"delay":0,"precondition":"","postcondition":"x' >= 10 && x' <= 1000"},{"id":"ea6b6d89-f52e-4f99-8c1c-40f91dec2912","position":{"x":180,"y":320},"label":"T5","width":20,"height":50,"isEnabled":false,"priority":1,"delay":0,"precondition":"x > 1500","postcondition":""},{"id":"cdf9d7e2-0d68-4205-8082-645f131760be","position":{"x":180,"y":450},"label":"T6","width":20,"height":50,"isEnabled":false,"priority":1,"delay":0,"precondition":"x < 1000","postcondition":""}],"arcs":[{"id":"0ead5a67-b105-499c-9151-db77b40c1b5c","source":"7dba29a8-befd-4629-a98a-85f76dac0b7c","target":"e1abe538-d03c-49aa-8dcd-2573765bfcc0","weight":1,"type":"regular","points":[],"label":"1"},{"id":"1e16ffe6-f9fc-4e1d-aab0-94a9eae9356a","source":"e1abe538-d03c-49aa-8dcd-2573765bfcc0","target":"2a9feebc-2c06-41ca-a8a0-f40c60edd9af","weight":1,"type":"regular","points":[],"label":"1"},{"id":"7602db43-e866-46cc-a951-4fce567363a4","source":"2a9feebc-2c06-41ca-a8a0-f40c60edd9af","target":"269f050e-06ad-4f3f-8204-3cf21dc05317","weight":1,"type":"regular","points":[],"label":"1"},{"id":"5b45cf98-d3e0-4250-ac58-f5d1657acc29","source":"269f050e-06ad-4f3f-8204-3cf21dc05317","target":"3d13bb93-6272-4e81-972c-b88c3d9a82de","weight":1,"type":"regular","points":[],"label":"1"},{"id":"3d7e7202-e900-4096-b801-79d6c430092a","source":"3d13bb93-6272-4e81-972c-b88c3d9a82de","target":"90c4c99f-912b-497a-a508-504881694aea","weight":1,"type":"regular","points":[],"label":"1"},{"id":"1f3db71a-f417-4ee9-9d76-9df8b5320519","source":"90c4c99f-912b-497a-a508-504881694aea","target":"a3741425-f8c9-496e-a2bf-641a7598879a","weight":1,"type":"regular","points":[],"label":"1"},{"id":"634097e9-c7ca-4b2e-b1ff-6cfb23b2c58e","source":"a3741425-f8c9-496e-a2bf-641a7598879a","target":"2429c8d1-2c99-4641-a019-12a42474ab65","weight":1,"type":"regular","points":[],"label":"1"},{"id":"f202e6db-f6e2-4091-9ba2-66acef987277","source":"2429c8d1-2c99-4641-a019-12a42474ab65","target":"9f546a8b-c950-42bb-a1a0-f43d821cb6ad","weight":1,"type":"regular","points":[],"label":"1"},{"id":"4433eda8-cdc8-45b9-9a23-6f0b6c57d69d","source":"9f546a8b-c950-42bb-a1a0-f43d821cb6ad","target":"ea6b6d89-f52e-4f99-8c1c-40f91dec2912","weight":1,"type":"regular","points":[],"label":"1"},{"id":"837a6333-a6d2-44e8-adc8-0fd07bb067b3","source":"9f546a8b-c950-42bb-a1a0-f43d821cb6ad","target":"cdf9d7e2-0d68-4205-8082-645f131760be","weight":1,"type":"regular","points":[],"label":"1"},{"id":"9d0a3ea2-a81f-479f-b242-ab375313ca9a","source":"ea6b6d89-f52e-4f99-8c1c-40f91dec2912","target":"cf3080fe-9a2a-4ef0-9667-718904c52896","weight":1,"type":"regular","points":[],"label":"1"},{"id":"26d4794b-ecbb-442f-9615-5caabede1998","source":"cdf9d7e2-0d68-4205-8082-645f131760be","target":"cf3080fe-9a2a-4ef0-9667-718904c52896","weight":1,"type":"regular","points":[],"label":"1"},{"id":"0da5cd56-c706-4541-99a9-c280f3f74faa","source":"7665ee86-ade0-41e9-8b0c-427f71ac4515","target":"cdf9d7e2-0d68-4205-8082-645f131760be","weight":1,"type":"regular","points":[],"label":"1"}],"dataVariables":[{"id":"d0ffbd5e-d81b-41f4-8d4b-6b16b6027691","name":"x","type":"number","currentValue":10,"description":""}]}
+{
+  "id": "35e8b8b7-23c1-4f76-96f1-e5555f3d7874",
+  "name": "New Petri Net",
+  "description": "",
+  "places": [
+    {
+      "id": "7dba29a8-befd-4629-a98a-85f76dac0b7c",
+      "position": {
+        "x": 210,
+        "y": 150
+      },
+      "label": "Start",
+      "tokens": 1,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "2a9feebc-2c06-41ca-a8a0-f40c60edd9af",
+      "position": {
+        "x": 500,
+        "y": 150
+      },
+      "label": "P2",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "3d13bb93-6272-4e81-972c-b88c3d9a82de",
+      "position": {
+        "x": 780,
+        "y": 150
+      },
+      "label": "P3",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "a3741425-f8c9-496e-a2bf-641a7598879a",
+      "position": {
+        "x": 620,
+        "y": 320
+      },
+      "label": "P4",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "9f546a8b-c950-42bb-a1a0-f43d821cb6ad",
+      "position": {
+        "x": 290,
+        "y": 320
+      },
+      "label": "P5",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "cf3080fe-9a2a-4ef0-9667-718904c52896",
+      "position": {
+        "x": 60,
+        "y": 320
+      },
+      "label": "P6",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    },
+    {
+      "id": "7665ee86-ade0-41e9-8b0c-427f71ac4515",
+      "position": {
+        "x": 340,
+        "y": 450
+      },
+      "label": "P7",
+      "tokens": 0,
+      "capacity": null,
+      "radius": 20
+    }
+  ],
+  "transitions": [
+    {
+      "id": "e1abe538-d03c-49aa-8dcd-2573765bfcc0",
+      "position": {
+        "x": 360,
+        "y": 150
+      },
+      "label": "T1",
+      "width": 20,
+      "height": 50,
+      "isEnabled": true,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "x' >= 10 and x' <= 1000"
+    },
+    {
+      "id": "269f050e-06ad-4f3f-8204-3cf21dc05317",
+      "position": {
+        "x": 620,
+        "y": 150
+      },
+      "label": "T2",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "x' >= 10 and x' <= 1000"
+    },
+    {
+      "id": "90c4c99f-912b-497a-a508-504881694aea",
+      "position": {
+        "x": 780,
+        "y": 310
+      },
+      "label": "T3",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "x' >= 10 and x' <= 1000"
+    },
+    {
+      "id": "2429c8d1-2c99-4641-a019-12a42474ab65",
+      "position": {
+        "x": 430,
+        "y": 320
+      },
+      "label": "T4",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "",
+      "postcondition": "x' >= 10 and x' <= 1000"
+    },
+    {
+      "id": "ea6b6d89-f52e-4f99-8c1c-40f91dec2912",
+      "position": {
+        "x": 180,
+        "y": 320
+      },
+      "label": "T5",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "x > 1500",
+      "postcondition": ""
+    },
+    {
+      "id": "cdf9d7e2-0d68-4205-8082-645f131760be",
+      "position": {
+        "x": 180,
+        "y": 450
+      },
+      "label": "T6",
+      "width": 20,
+      "height": 50,
+      "isEnabled": false,
+      "priority": 1,
+      "delay": 0,
+      "precondition": "x < 1000",
+      "postcondition": ""
+    }
+  ],
+  "arcs": [
+    {
+      "id": "0ead5a67-b105-499c-9151-db77b40c1b5c",
+      "source": "7dba29a8-befd-4629-a98a-85f76dac0b7c",
+      "target": "e1abe538-d03c-49aa-8dcd-2573765bfcc0",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "1e16ffe6-f9fc-4e1d-aab0-94a9eae9356a",
+      "source": "e1abe538-d03c-49aa-8dcd-2573765bfcc0",
+      "target": "2a9feebc-2c06-41ca-a8a0-f40c60edd9af",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "7602db43-e866-46cc-a951-4fce567363a4",
+      "source": "2a9feebc-2c06-41ca-a8a0-f40c60edd9af",
+      "target": "269f050e-06ad-4f3f-8204-3cf21dc05317",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "5b45cf98-d3e0-4250-ac58-f5d1657acc29",
+      "source": "269f050e-06ad-4f3f-8204-3cf21dc05317",
+      "target": "3d13bb93-6272-4e81-972c-b88c3d9a82de",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "3d7e7202-e900-4096-b801-79d6c430092a",
+      "source": "3d13bb93-6272-4e81-972c-b88c3d9a82de",
+      "target": "90c4c99f-912b-497a-a508-504881694aea",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "1f3db71a-f417-4ee9-9d76-9df8b5320519",
+      "source": "90c4c99f-912b-497a-a508-504881694aea",
+      "target": "a3741425-f8c9-496e-a2bf-641a7598879a",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "634097e9-c7ca-4b2e-b1ff-6cfb23b2c58e",
+      "source": "a3741425-f8c9-496e-a2bf-641a7598879a",
+      "target": "2429c8d1-2c99-4641-a019-12a42474ab65",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "f202e6db-f6e2-4091-9ba2-66acef987277",
+      "source": "2429c8d1-2c99-4641-a019-12a42474ab65",
+      "target": "9f546a8b-c950-42bb-a1a0-f43d821cb6ad",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "4433eda8-cdc8-45b9-9a23-6f0b6c57d69d",
+      "source": "9f546a8b-c950-42bb-a1a0-f43d821cb6ad",
+      "target": "ea6b6d89-f52e-4f99-8c1c-40f91dec2912",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "837a6333-a6d2-44e8-adc8-0fd07bb067b3",
+      "source": "9f546a8b-c950-42bb-a1a0-f43d821cb6ad",
+      "target": "cdf9d7e2-0d68-4205-8082-645f131760be",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "9d0a3ea2-a81f-479f-b242-ab375313ca9a",
+      "source": "ea6b6d89-f52e-4f99-8c1c-40f91dec2912",
+      "target": "cf3080fe-9a2a-4ef0-9667-718904c52896",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "26d4794b-ecbb-442f-9615-5caabede1998",
+      "source": "cdf9d7e2-0d68-4205-8082-645f131760be",
+      "target": "cf3080fe-9a2a-4ef0-9667-718904c52896",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    },
+    {
+      "id": "0da5cd56-c706-4541-99a9-c280f3f74faa",
+      "source": "7665ee86-ade0-41e9-8b0c-427f71ac4515",
+      "target": "cdf9d7e2-0d68-4205-8082-645f131760be",
+      "weight": 1,
+      "type": "regular",
+      "points": [],
+      "label": "1"
+    }
+  ],
+  "dataVariables": [
+    {
+      "id": "d0ffbd5e-d81b-41f4-8d4b-6b16b6027691",
+      "name": "x",
+      "type": "real",
+      "currentValue": 10,
+      "description": ""
+    }
+  ]
+}

--- a/scripts/migrate-examples.mjs
+++ b/scripts/migrate-examples.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+/**
+ * One-time migration script: update example JSON files from legacy JS guard syntax
+ * to the new guard language syntax.
+ * 
+ * Usage: node scripts/migrate-examples.mjs
+ */
+
+import { readFileSync, writeFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+
+const EXAMPLES_DIR = new URL('../public/examples', import.meta.url).pathname;
+
+// --- Simple text-level migration (same logic as guard-migrator.js) ---
+
+function migrateExpr(expr, isPost) {
+  if (!expr || typeof expr !== 'string') return expr;
+  let s = expr.trim();
+  if (!s) return s;
+
+  // Replace JS operators
+  s = s.replace(/===/g, '=');
+  s = s.replace(/!==/g, 'distinct');
+  s = s.replace(/!=/g, 'distinct');
+  s = s.replace(/==/g, '=');
+  s = s.replace(/&&/g, 'and');
+  s = s.replace(/\|\|/g, 'or');
+
+  if (isPost) {
+    // Replace semicolons with 'and', handling trailing ones
+    // Remove trailing semicolons first
+    s = s.replace(/;\s*$/, '');
+    // Replace remaining semicolons with 'and'
+    s = s.replace(/\s*;\s*/g, ' and ');
+  }
+
+  return s.trim();
+}
+
+function normalizeType(type) {
+  const t = (type || 'real').toLowerCase().trim();
+  switch (t) {
+    case 'int': case 'integer': return 'int';
+    case 'bool': case 'boolean': return 'bool';
+    case 'real': case 'float': case 'number': case 'string': return 'real';
+    default: return 'real';
+  }
+}
+
+// --- Process all JSON files ---
+
+const files = readdirSync(EXAMPLES_DIR).filter(f => f.endsWith('.json'));
+let totalChanges = 0;
+
+for (const file of files) {
+  const filePath = join(EXAMPLES_DIR, file);
+  let content;
+  try {
+    content = JSON.parse(readFileSync(filePath, 'utf-8'));
+  } catch (e) {
+    console.warn(`  Skipping ${file}: ${e.message}`);
+    continue;
+  }
+
+  let changed = false;
+
+  // Process transitions
+  const transitions = content.transitions || [];
+  for (const t of transitions) {
+    if (t.precondition) {
+      const migrated = migrateExpr(t.precondition, false);
+      if (migrated !== t.precondition) {
+        console.log(`  ${file}: ${t.label || t.id} pre: "${t.precondition}" → "${migrated}"`);
+        t.precondition = migrated;
+        changed = true;
+      }
+    }
+    if (t.postcondition) {
+      const migrated = migrateExpr(t.postcondition, true);
+      if (migrated !== t.postcondition) {
+        console.log(`  ${file}: ${t.label || t.id} post: "${t.postcondition}" → "${migrated}"`);
+        t.postcondition = migrated;
+        changed = true;
+      }
+    }
+  }
+
+  // Process data variables
+  const dataVars = content.dataVariables || [];
+  for (const v of dataVars) {
+    if (v.type) {
+      const norm = normalizeType(v.type);
+      if (norm !== v.type) {
+        console.log(`  ${file}: var ${v.name}: type "${v.type}" → "${norm}"`);
+        v.type = norm;
+        changed = true;
+      }
+    }
+  }
+
+  // Process final marking constraints
+  if (content.finalMarkingConstraints) {
+    for (const c of content.finalMarkingConstraints) {
+      if (c.expression) {
+        const migrated = migrateExpr(c.expression, false);
+        if (migrated !== c.expression) {
+          console.log(`  ${file}: final marking: "${c.expression}" → "${migrated}"`);
+          c.expression = migrated;
+          changed = true;
+        }
+      }
+    }
+  }
+
+  if (changed) {
+    writeFileSync(filePath, JSON.stringify(content, null, 2) + '\n', 'utf-8');
+    totalChanges++;
+    console.log(`  ✓ Updated ${file}`);
+  }
+}
+
+console.log(`\nDone. ${totalChanges} file(s) updated out of ${files.length} total.`);

--- a/src/extensions/dpn-api.js
+++ b/src/extensions/dpn-api.js
@@ -1,6 +1,7 @@
 
 import { PetriNetAPI, Place, Transition, Arc } from '../petri-net-simulator.js';
 import { DataPetriNet, DataAwareTransition, DataVariable } from './dpn-model.js';
+import { validatePrecondition, validatePostcondition } from './guard-language/guard-validator.js';
 
 class DataPetriNetAPI extends PetriNetAPI {
   /**
@@ -47,7 +48,7 @@ class DataPetriNetAPI extends PetriNetAPI {
   /**
    * Create a new data variable
    * @param {string} name - Name of the variable
-   * @param {string} type - Data type ('int', 'float', 'string', 'boolean')
+   * @param {string} type - Data type ('int'|'integer'|'bool'|'boolean'|'real')
    * @param {*} initialValue - Initial value
    * @param {string} description - Optional description
    * @returns {string} ID of the created variable
@@ -251,16 +252,10 @@ class DataPetriNetAPI extends PetriNetAPI {
 
       // Add new variables
       for (const varData of variables) {
-        // Handle legacy 'number' type by converting to 'int'
-        let variableType = varData.type;
-        if (variableType === 'number') {
-          variableType = 'int';
-        }
-        
         const variable = new DataVariable(
           varData.id || this.generateUUID(),
           varData.name,
-          variableType,
+          varData.type, // normalizeType is called in the constructor
           varData.currentValue,
           varData.description || ""
         );
@@ -284,140 +279,26 @@ class DataPetriNetAPI extends PetriNetAPI {
    * Validate a precondition expression
    * @param {string} expression - Precondition expression to validate
    * @param {Array<string>} variableNames - Available variable names
-   * @returns {Object} Validation result {valid: boolean, error: string}
+   * @returns {Object} Validation result {valid: boolean, error: string|null, pos: number|null}
    */
   validatePrecondition(expression, variableNames = []) {
     if (!expression.trim()) {
-      return { valid: true, error: null }; // Empty expression is valid
+      return { valid: true, error: null, pos: null };
     }
-
-    try {
-      // Create dummy valuation
-      const dummyValuation = {};
-      variableNames.forEach(name => {
-        dummyValuation[name] = 0; // Use 0 as a safe default for validation
-      });
-
-      // Create evaluator function
-      const functionBody = `return ${expression};`;
-      const evaluator = new Function(...variableNames, functionBody);
-
-      // Test evaluation
-      evaluator(...variableNames.map(name => dummyValuation[name]));
-
-      return { valid: true, error: null };
-    } catch (error) {
-      return {
-        valid: false,
-        error: `Invalid expression: ${error.message}`
-      };
-    }
+    return validatePrecondition(expression, variableNames);
   }
 
   /**
    * Validate a postcondition expression
    * @param {string} expression - Postcondition expression to validate
    * @param {Array<string>} variableNames - Available variable names
-   * @returns {Object} Validation result {valid: boolean, error: string}
+   * @returns {Object} Validation result {valid: boolean, error: string|null, pos: number|null}
    */
   validatePostcondition(expression, variableNames = []) {
     if (!expression.trim()) {
-      return { valid: true, error: null }; // Empty expression is valid
+      return { valid: true, error: null, pos: null };
     }
-  
-    // Split into statements
-    const statements = expression.split(';');
-    
-    for (const statement of statements) {
-      if (!statement.trim()) continue;
-      
-      // Check for assignment pattern
-      const assignMatch = statement.trim().match(/^([a-zA-Z_][a-zA-Z0-9_]*)'\s*=\s*(.+)/);
-      
-      if (assignMatch) {
-        // Direct assignment validation
-        const [, variableName, rightHandSide] = assignMatch;
-        
-        // Check if variable exists
-        if (!variableNames.includes(variableName)) {
-          return {
-            valid: false,
-            error: `Unknown variable: ${variableName}`
-          };
-        }
-        
-        // Validate right-hand side expression
-        try {
-          // Create dummy valuation
-          const dummyValuation = {};
-          variableNames.forEach(name => {
-            dummyValuation[name] = 0; // Use 0 as a safe default for validation
-          });
-          
-          // Process expression (remove primes)
-          let processedExpression = rightHandSide;
-          variableNames.forEach(name => {
-            const regex = new RegExp(`${name}'`, 'g');
-            processedExpression = processedExpression.replace(regex, name);
-          });
-          
-          // Create and test evaluator
-          const evaluator = new Function(...variableNames, `return (${processedExpression});`);
-          evaluator(...variableNames.map(name => dummyValuation[name]));
-        } catch (error) {
-          return { 
-            valid: false, 
-            error: `Invalid expression in "${statement}": ${error.message}` 
-          };
-        }
-      } else {
-        // Check for constraint pattern
-        const primedVarsUsed = variableNames.filter(name => 
-          statement.match(new RegExp(`${name}'`, 'g'))
-        );
-        
-        if (primedVarsUsed.length === 0) {
-          return {
-            valid: false,
-            error: `Statement "${statement}" is not a valid assignment or constraint. It should either be an assignment (x' = expr) or a constraint involving primed variables (x' > 0).`
-          };
-        }
-        
-        // Validate constraint expression
-        try {
-          // Create dummy valuation
-          const dummyValuation = {};
-          variableNames.forEach(name => {
-            dummyValuation[name] = 0; // Use 0 as a safe default for validation
-          });
-          
-          const dummyTestValuation = { ...dummyValuation };
-          
-          // Process expression for validation
-          let processedExpression = statement;
-          variableNames.forEach(name => {
-            const regex = new RegExp(`${name}'`, 'g');
-            processedExpression = processedExpression.replace(regex, `dummyTestValuation["${name}"]`);
-          });
-          
-          // Create and test evaluator
-          const evaluator = new Function(
-            ...variableNames,
-            'dummyTestValuation',
-            `return (${processedExpression});`
-          );
-          
-          evaluator(...variableNames.map(name => dummyValuation[name]), dummyTestValuation);
-        } catch (error) {
-          return {
-            valid: false,
-            error: `Invalid constraint in "${statement}": ${error.message}`
-          };
-        }
-      }
-    }
-    
-    return { valid: true, error: null };
+    return validatePostcondition(expression, variableNames);
   }
 
   /**
@@ -428,31 +309,32 @@ class DataPetriNetAPI extends PetriNetAPI {
     return {
       precondition: `
   Precondition (Guard) Help:
-  - JavaScript expression that evaluates to true/false
+  - Guard expression that evaluates to true/false
   - Determines when a transition is enabled
-  - Example: x > 5 && y === "ready"
+  - Two forms supported:
+    1. Infix: x > 5 and y = 1
+    2. SMT prefix: (and (> x 5) (= y 1))
+  - Operators: =, distinct, <, <=, >, >=, +, -, *, /
+  - Logical: and, or, not, => (implies)
+  - No primed variables (x') allowed in preconditions
   - Available variables: ${Array.from(this.petriNet.dataVariables.values()).map(v => v.name).join(', ')}
       `,
       postcondition: `
   Postcondition (Data Update) Help:
   - Defines how variables change when transition fires
+  - Use primed variables (x') for next-state values
   - Two supported formats:
-    1. Direct assignment: variable' = expression;
-       Example: x' = x + 1; y' = "done";
-    
-    2. Constraint-based random assignment: expression containing variable';
-       Example: x' > 0 && x' < x*2;
-       (generates a random value satisfying the constraints)
-       
-  - Use semicolons to separate multiple assignments/constraints
+    1. Direct assignment: x' = x + 1 and y' = 0
+    2. Constraint-based: x' > 0 and x' < x * 2
+       (generates a value satisfying the constraints)
+  - Use 'and' to combine multiple assignments/constraints
   - Direct assignments have priority over constraints
   - Available variables: ${Array.from(this.petriNet.dataVariables.values()).map(v => v.name).join(', ')}
   
   Data Types:
-  - int: Whole numbers (42, -7, 0)
-  - float: Decimal numbers (3.14, -2.5, 1.0)
-  - string: Text values ("hello", "processing")
-  - boolean: true or false values
+  - int / integer: Whole numbers (42, -7, 0)
+  - real: Decimal numbers (3.14, -2.5, 1.0)
+  - bool / boolean: true or false values
       `
     };
   }

--- a/src/extensions/dpn-model.js
+++ b/src/extensions/dpn-model.js
@@ -1,5 +1,7 @@
 import { Transition, PetriNet, Place, Arc } from '../petri-net-simulator.js';
 import { solveExpressionWithWebPPL } from './probabilistic-execution.js';
+import { parse } from './guard-language/guard-parser.js';
+import { evaluatePrecondition as evalPre, evaluatePostcondition as evalPost, checkConstraint, constraintToString, getWrittenVariables } from './guard-language/guard-evaluator.js';
 
 /**
  * Represents a data variable in a Data Petri Net
@@ -9,16 +11,31 @@ class DataVariable {
    * Create a new data variable
    * @param {string} id - Unique identifier for the variable
    * @param {string} name - Human-readable name of the variable
-   * @param {string} type - Data type ('int', 'float', 'string', 'boolean')
+   * @param {string} type - Data type ('int'|'integer'|'bool'|'boolean'|'real')
    * @param {*} initialValue - Initial value of the variable
    * @param {string} description - Optional description of the variable
    */
   constructor(id, name, type, initialValue = null, description = "") {
     this.id = id;
     this.name = name;
-    this.type = type;
+    this.type = DataVariable.normalizeType(type);
     this.currentValue = initialValue;
     this.description = description;
+  }
+
+  /**
+   * Normalize type aliases to canonical forms
+   * @param {string} type - Raw type string
+   * @returns {string} Normalized type: 'int', 'bool', or 'real'
+   */
+  static normalizeType(type) {
+    const t = (type || 'real').toLowerCase();
+    if (t === 'int' || t === 'integer') return 'int';
+    if (t === 'bool' || t === 'boolean') return 'bool';
+    if (t === 'real' || t === 'float' || t === 'number') return 'real';
+    // Legacy: treat 'string' as 'int' (integer encoding)
+    if (t === 'string') return 'int';
+    return 'real';
   }
 
   /**
@@ -31,13 +48,11 @@ class DataVariable {
     switch (this.type) {
       case 'int':
         return Math.floor(Number(this.currentValue));
-      case 'float':
-        return Number(this.currentValue);
-      case 'boolean':
+      case 'bool':
         return Boolean(this.currentValue);
-      case 'string':
+      case 'real':
       default:
-        return String(this.currentValue);
+        return Number(this.currentValue);
     }
   }
 
@@ -49,27 +64,26 @@ class DataVariable {
   setValue(value) {
     try {
       switch (this.type) {
-        case 'int':
+        case 'int': {
           const intValue = Number(value);
           if (isNaN(intValue)) {
             throw new Error('Not a valid integer');
           }
           this.currentValue = Math.floor(intValue);
           break;
-        case 'float':
-          const floatValue = Number(value);
-          if (isNaN(floatValue)) {
-            throw new Error('Not a valid float');
-          }
-          this.currentValue = floatValue;
-          break;
-        case 'boolean':
+        }
+        case 'bool':
           this.currentValue = Boolean(value);
           break;
-        case 'string':
-        default:
-          this.currentValue = String(value);
+        case 'real':
+        default: {
+          const realValue = Number(value);
+          if (isNaN(realValue)) {
+            throw new Error('Not a valid real number');
+          }
+          this.currentValue = realValue;
           break;
+        }
       }
       return true;
     } catch (error) {
@@ -118,12 +132,8 @@ class DataAwareTransition extends Transition {
     }
 
     try {
-      const variableNames = Object.keys(valuation);
-      const variableValues = variableNames.map(name => valuation[name]);
-      const functionBody = `return ${this.precondition};`;
-      const evaluator = new Function(...variableNames, functionBody);
-
-      return Boolean(evaluator(...variableValues));
+      const { ast } = parse(this.precondition, { isPostcondition: false });
+      return evalPre(ast, valuation);
     } catch (error) {
       console.error(`Error evaluating precondition for transition ${this.id}:`, error);
       console.error(`Precondition: ${this.precondition}`);
@@ -144,52 +154,67 @@ class DataAwareTransition extends Transition {
   
     try {
       const newValuation = { ...valuation };
-      const statements = this.postcondition.split(';');
-      
-      // First pass: Handle direct assignments
-      for (const statement of statements) {
-        if (!statement.trim()) continue;
-        
-        const assignMatch = statement.trim().match(/([a-zA-Z_][a-zA-Z0-9_]*)'\s*=\s*(.+)/);
-        if (!assignMatch) continue; // Skip non-assignments for now
-        
-        const [, variableName, expression] = assignMatch;
-        if (!(variableName in valuation)) continue;
-        
-        const expressionFunction = this.createExpressionEvaluator(expression, Object.keys(valuation));
-        newValuation[variableName] = expressionFunction(...Object.values(valuation));
-      }
-      
-      // Second pass: Handle constraint-based assignments
-      const constraintStatements = statements.filter(stmt => {
-        if (!stmt.trim()) return false;
-        return !stmt.trim().match(/^[a-zA-Z_][a-zA-Z0-9_]*'\s*=/) && 
-               stmt.trim().match(/[a-zA-Z_][a-zA-Z0-9_]*'/);
-      });
+      const { ast } = parse(this.postcondition, { isPostcondition: true });
+      const { assignments, constraints } = evalPost(ast, valuation);
 
-      if (constraintStatements.length > 0) {
-        const primedVars = new Set();
-        for (const stmt of constraintStatements) {
-          this.detectPrimedVariables(stmt).forEach(v => primedVars.add(v));
+      // Apply direct assignments
+      for (const [varName, value] of assignments) {
+        if (varName in valuation) {
+          newValuation[varName] = value;
         }
+      }
+
+      // Handle constraint-based assignments via WebPPL solver
+      if (constraints.length > 0) {
+        const primedVars = getWrittenVariables(ast);
         
         for (const variableName of primedVars) {
           if (!(variableName in valuation)) continue;
-          
           // Skip if already handled by direct assignment
-          if (statements.some(stmt => 
-            stmt.trim().match(new RegExp(`^${variableName}'\s*=`)))) {
+          if (assignments.has(variableName)) continue;
+
+          const currentValue = valuation[variableName];
+
+          // For boolean variables, try both values directly
+          if (typeof currentValue === 'boolean') {
+            const trueOk = constraints.every(c => checkConstraint(c, valuation, { ...newValuation, [variableName]: true }));
+            const falseOk = constraints.every(c => checkConstraint(c, valuation, { ...newValuation, [variableName]: false }));
+            if (trueOk) { newValuation[variableName] = true; continue; }
+            if (falseOk) { newValuation[variableName] = false; continue; }
             continue;
           }
-          
-          // Use constraint-based assignment with proper type
-          newValuation[variableName] = await this.findValueSatisfyingConstraints(
-            variableName,
-            constraintStatements,
-            valuation,
-            newValuation
-          );
-          console.log(`Found value for ${variableName}: ${newValuation[variableName]}`);
+
+          // For numeric variables, use WebPPL solver
+          if (typeof currentValue === 'number') {
+            try {
+              const combinedConstraint = constraints.map(c => constraintToString(c)).join(' && ');
+              let variableType = 'int';
+              if (window.petriApp && window.petriApp.api && window.petriApp.api.petriNet && window.petriApp.api.petriNet.dataVariables) {
+                for (const [, variable] of window.petriApp.api.petriNet.dataVariables) {
+                  if (variable.name === variableName) {
+                    variableType = variable.type;
+                    break;
+                  }
+                }
+              }
+              
+              const result = await solveExpressionWithWebPPL(
+                combinedConstraint, 
+                newValuation, 
+                variableType === 'real' ? 'float' : 'int'
+              );
+              
+              if (result && result.success && result.newValues && result.newValues[variableName] !== undefined) {
+                if (variableType === 'int') {
+                  newValuation[variableName] = Math.floor(Number(result.newValues[variableName]));
+                } else {
+                  newValuation[variableName] = Number(result.newValues[variableName]);
+                }
+              }
+            } catch (error) {
+              console.error('[DPN] Error using WebPPL solver:', error);
+            }
+          }
         }
       }
       
@@ -202,203 +227,6 @@ class DataAwareTransition extends Transition {
     }
   }
   
-  /**
-   * Helper method to detect primed variables in an expression
-   * @param {string} expression - The expression to analyze
-   * @returns {Array<string>} Array of variable names (without primes)
-   */
-  detectPrimedVariables(expression) {
-    const primeRegex = /([a-zA-Z_][a-zA-Z0-9_]*)'/g;
-    const matches = expression.match(primeRegex) || [];
-    return matches.map(match => match.slice(0, -1));
-  }
-  
-  /**
-   * Check if a specific value satisfies all constraint statements
-   * @param {*} value - The value to check
-   * @param {string} variableName - The variable name
-   * @param {Array<string>} constraintStatements - Array of constraint expressions
-   * @param {Object} originalValuation - Original variable values
-   * @param {Object} currentValuation - Current working variable values
-   * @returns {boolean} Whether the value satisfies all constraints
-   */
-  checkValueAgainstConstraints(value, variableName, constraintStatements, originalValuation, currentValuation) {
-    const testValuation = { ...currentValuation };
-    testValuation[variableName] = value;
-    
-    for (const statement of constraintStatements) {
-      const constraintFunction = this.createConstraintEvaluator(
-        statement,
-        Object.keys(originalValuation),
-        testValuation
-      );
-      
-      try {
-        if (!constraintFunction(...Object.values(originalValuation), testValuation)) {
-          return false;
-        }
-      } catch (error) {
-        console.error(`Error evaluating constraint: ${statement}`, error);
-        return false;
-      }
-    }
-    
-    return true;
-  }
-
-  /**
-   * Create a function to evaluate a constraint with primed variables
-   * @param {string} constraintExpression - The constraint expression
-   * @param {Array<string>} variableNames - Array of variable names
-   * @param {Object} testValuation - The test valuation object containing potential new values
-   * @returns {Function} A function that evaluates the constraint
-   */
-  createConstraintEvaluator(constraintExpression, variableNames, testValuation) {
-    let processedExpression = constraintExpression.trim();
-
-    const functionBody = `
-      try {
-        ${variableNames.map(name => `const ${name}_prime = testValuation["${name}"];`).join('\n        ')}
-        
-        const result = (${processedExpression.replace(
-          new RegExp(`(^|[^\\w])([a-zA-Z_][a-zA-Z0-9_]*)'`, 'g'), 
-          (match, prefix, varName) => {
-            if (variableNames.includes(varName)) {
-              return `${prefix}${varName}_prime`;
-            }
-            return match;
-          }
-        )});
-        
-        return !!result;
-      } catch (e) {
-        console.error("Error in constraint evaluation:", e);
-        return false;
-      }
-    `;
-    
-    return new Function(...variableNames, 'testValuation', functionBody);
-  }
-
-/**
- * Find a value that satisfies all constraint statements for a variable (ASYNC)
- * @param {string} variableName - The variable name to generate a value for
- * @param {Array<string>} constraintStatements - Array of constraint expressions
- * @param {Object} originalValuation - Original variable values
- * @param {Object} currentValuation - Current working variable values
- * @returns {Promise<*>} A value that satisfies all constraints
- */
-async findValueSatisfyingConstraints(variableName, constraintStatements, originalValuation, currentValuation) {
-  const currentValue = originalValuation[variableName];
-  console.log("[DPN] Finding value for constraints", variableName, constraintStatements);
-
-  // [Section 5.2] For boolean variables, use direct constraint checking
-  // since sampling doesn't make sense for binary domains
-  if (typeof currentValue === 'boolean') {
-    if (this.checkValueAgainstConstraints(true, variableName, constraintStatements, originalValuation, currentValuation)) {
-      return true;
-    }
-    if (this.checkValueAgainstConstraints(false, variableName, constraintStatements, originalValuation, currentValuation)) {
-      return false;
-    }
-    return currentValue; // Fallback to current value
-  }
-
-  // [Section 5.2] Use WebPPL-based probabilistic approach for numeric constraints
-  // Following paper: "ui := SV(ui)" followed by "observe post(t)"
-  if (typeof currentValue === 'number') {
-    try {
-      const combinedConstraint = constraintStatements.join(' && ');
-      console.log('[DPN] Combined constraints:', combinedConstraint);
-      console.log('[DPN] Using WebPPL-based probabilistic solver (paper Section 5.2)');
-      
-      // Determine variable type for proper handling
-      let variableType = 'int'; // default fallback
-      
-      if (window.petriApp && window.petriApp.api && window.petriApp.api.petriNet && window.petriApp.api.petriNet.dataVariables) {
-        for (const [id, variable] of window.petriApp.api.petriNet.dataVariables) {
-          if (variable.name === variableName) {
-            variableType = variable.type;
-            // Handle legacy 'number' type
-            if (variableType === 'number') {
-              variableType = 'int';
-            }
-            break;
-          }
-        }
-      }
-      
-      // [Section 5.2] Call WebPPL-based solver implementing sample+observe pattern
-      const result = await solveExpressionWithWebPPL(
-        combinedConstraint, 
-        currentValuation, 
-        variableType === 'float' ? 'float' : 'int'
-      );
-      
-      console.log('[DPN] WebPPL solver result:', result);
-      
-      if (result && result.success && result.newValues && result.newValues[variableName] !== undefined) {
-        console.log(`[DPN] WebPPL solver found value for ${variableName}: ${result.newValues[variableName]}`);
-        
-        // Ensure the result matches the expected type
-        if (variableType === 'int') {
-          return Math.floor(Number(result.newValues[variableName]));
-        } else if (variableType === 'float') {
-          return Number(result.newValues[variableName]);
-        } else {
-          return result.newValues[variableName];
-        }
-      }
-    } catch (error) {
-      console.error('[DPN] Error using WebPPL solver:', error);
-    }
-    
-    // Fallback to current value if solver fails
-    console.warn(`[DPN] Solver failed for ${variableName}, keeping current value:`, currentValue);
-    return currentValue;
-  } 
-  
-  // [Section 5.2] For string variables, use WebPPL with auto detection
-  if (typeof currentValue === 'string') {
-    try {
-      console.log('[DPN] String variable, using WebPPL solver');
-      const result = await solveExpressionWithWebPPL(
-        constraintStatements.join(' && '), 
-        currentValuation, 
-        'auto'
-      );
-      
-      if (result && result.success && result.newValues && result.newValues[variableName] !== undefined) {
-        console.log(`[DPN] WebPPL solver found value for string ${variableName}: ${result.newValues[variableName]}`);
-        return String(result.newValues[variableName]);
-      }
-    } catch (error) {
-      console.error('[DPN] Error using WebPPL solver for string:', error);
-    }
-    
-    // Fallback for strings - return current value
-    return currentValue;
-  }
-  
-  return currentValue;
-}
-
-  /**
-   * Create a function to evaluate an expression
-   * @param {string} expression - The expression to evaluate
-   * @param {Array<string>} variables - Array of variable names
-   * @returns {Function} A function that evaluates the expression
-   * @private
-   */
-  createExpressionEvaluator(expression, variables) {
-    let processedExpression = expression;
-    variables.forEach(name => {
-      const regex = new RegExp(`${name}'`, 'g');
-      processedExpression = processedExpression.replace(regex, name);
-    });
-
-    return new Function(...variables, `return (${processedExpression});`);
-  }
 }
 
 /**
@@ -855,16 +683,10 @@ class DataPetriNet extends PetriNet {
 
     if (data.dataVariables) {
       data.dataVariables.forEach((variableData) => {
-        // Handle legacy 'number' type by converting to 'int'
-        let variableType = variableData.type;
-        if (variableType === 'number') {
-          variableType = 'int';
-        }
-        
         const variable = new DataVariable(
           variableData.id,
           variableData.name,
-          variableType,
+          variableData.type, // normalizeType is called in the constructor
           variableData.currentValue,
           variableData.description
         );
@@ -1014,16 +836,13 @@ class DataPetriNet extends PetriNet {
           case 'int':
             javaType = 'java.lang.Integer';
             break;
-          case 'float':
+          case 'real':
             javaType = 'java.lang.Double';
             maxValue = '100000.0';
             break;
-          case 'boolean':
+          case 'bool':
             javaType = 'java.lang.Boolean';
             maxValue = '100000';
-            break;
-          case 'string':
-            javaType = 'java.lang.String';
             break;
         }
 
@@ -1051,30 +870,18 @@ class DataPetriNet extends PetriNet {
    * @private
    */
   extractModifiedVariables(postcondition) {
-    const modifiedVars = new Set();
-    
-    // Split by semicolon to handle multiple statements
-    const statements = postcondition.split(';');
-    
-    for (const statement of statements) {
-      if (!statement.trim()) continue;
-      
-      // Look for assignment patterns: variableName' = ...
-      const assignMatch = statement.trim().match(/^([a-zA-Z_][a-zA-Z0-9_]*)'\s*=/);
-      if (assignMatch) {
-        modifiedVars.add(assignMatch[1]);
-      } else {
-        // Look for constraint patterns: expressions containing variableName'
-        const primeMatches = statement.match(/([a-zA-Z_][a-zA-Z0-9_]*)'/g);
-        if (primeMatches) {
-          primeMatches.forEach(match => {
-            modifiedVars.add(match.slice(0, -1)); // Remove the prime
-          });
-        }
+    try {
+      const { ast } = parse(postcondition, { isPostcondition: true });
+      return Array.from(getWrittenVariables(ast));
+    } catch {
+      // Fallback to regex if parsing fails
+      const modifiedVars = new Set();
+      const primeMatches = postcondition.match(/([a-zA-Z_][a-zA-Z0-9_]*)'/g);
+      if (primeMatches) {
+        primeMatches.forEach(match => modifiedVars.add(match.slice(0, -1)));
       }
+      return Array.from(modifiedVars);
     }
-    
-    return Array.from(modifiedVars);
   }
 }
 

--- a/src/extensions/dpn-ui.js
+++ b/src/extensions/dpn-ui.js
@@ -31,26 +31,24 @@ class ExpressionEditorDialog {
     if (this.type === 'precondition') {
       return {
         comparison: [
+          { label: '=', value: ' = ', description: 'Equal' },
+          { label: 'distinct', value: ' distinct ', description: 'Not equal' },
           { label: '>', value: ' > ', description: 'Greater than' },
           { label: '<', value: ' < ', description: 'Less than' },
           { label: '>=', value: ' >= ', description: 'Greater or equal' },
-          { label: '<=', value: ' <= ', description: 'Less or equal' },
-          { label: '===', value: ' === ', description: 'Strict equal' },
-          { label: '!==', value: ' !== ', description: 'Strict not equal' },
-          { label: '==', value: ' == ', description: 'Equal' },
-          { label: '!=', value: ' != ', description: 'Not equal' }
+          { label: '<=', value: ' <= ', description: 'Less or equal' }
         ],
         logical: [
-          { label: '&&', value: ' && ', description: 'Logical AND' },
-          { label: '||', value: ' || ', description: 'Logical OR' },
-          { label: '!', value: '!', description: 'Logical NOT' }
+          { label: 'and', value: ' and ', description: 'Logical AND' },
+          { label: 'or', value: ' or ', description: 'Logical OR' },
+          { label: 'not', value: 'not ', description: 'Logical NOT' },
+          { label: '=>', value: ' => ', description: 'Implies' }
         ],
         arithmetic: [
           { label: '+', value: ' + ', description: 'Add' },
           { label: '-', value: ' - ', description: 'Subtract' },
           { label: '*', value: ' * ', description: 'Multiply' },
-          { label: '/', value: ' / ', description: 'Divide' },
-          { label: '%', value: ' % ', description: 'Modulo' }
+          { label: '/', value: ' / ', description: 'Divide' }
         ],
         grouping: [
           { label: '( )', value: '()', description: 'Parentheses', cursorOffset: -1 }
@@ -64,26 +62,25 @@ class ExpressionEditorDialog {
       // Postcondition operators
       return {
         assignment: [
-          { label: "=' =", value: "' = ", description: 'Assignment (primed)', insertPrimed: true },
-          { label: ';', value: '; ', description: 'Statement separator' }
+          { label: "x' =", value: "' = ", description: 'Assignment (primed)', insertPrimed: true }
         ],
         comparison: [
+          { label: '=', value: ' = ', description: 'Equal' },
+          { label: 'distinct', value: ' distinct ', description: 'Not equal' },
           { label: '>', value: ' > ', description: 'Greater than (constraint)' },
           { label: '<', value: ' < ', description: 'Less than (constraint)' },
           { label: '>=', value: ' >= ', description: 'Greater or equal (constraint)' },
-          { label: '<=', value: ' <= ', description: 'Less or equal (constraint)' },
-          { label: '==', value: ' == ', description: 'Equal (constraint)' }
+          { label: '<=', value: ' <= ', description: 'Less or equal (constraint)' }
         ],
         arithmetic: [
           { label: '+', value: ' + ', description: 'Add' },
           { label: '-', value: ' - ', description: 'Subtract' },
           { label: '*', value: ' * ', description: 'Multiply' },
-          { label: '/', value: ' / ', description: 'Divide' },
-          { label: '%', value: ' % ', description: 'Modulo' }
+          { label: '/', value: ' / ', description: 'Divide' }
         ],
         logical: [
-          { label: '&&', value: ' && ', description: 'Logical AND (for constraints)' },
-          { label: '||', value: ' || ', description: 'Logical OR (for constraints)' }
+          { label: 'and', value: ' and ', description: 'Conjunction (combine assignments/constraints)' },
+          { label: 'or', value: ' or ', description: 'Logical OR (for constraints)' }
         ],
         grouping: [
           { label: '( )', value: '()', description: 'Parentheses', cursorOffset: -1 }
@@ -127,11 +124,19 @@ class ExpressionEditorDialog {
       validationStatus.className = 'expr-validation-status valid';
       validationStatus.textContent = '✓ Valid';
       validationMessage.textContent = '';
+      this.textarea.classList.remove('expr-textarea-error');
       this.dialog.querySelector('#btn-save-expression').disabled = false;
     } else {
       validationStatus.className = 'expr-validation-status invalid';
       validationStatus.textContent = '✗ Invalid';
-      validationMessage.textContent = validationResult.error || 'Invalid expression';
+      const pos = validationResult.pos;
+      const errorMsg = validationResult.error || 'Invalid expression';
+      validationMessage.textContent = pos != null ? `[col ${pos + 1}] ${errorMsg}` : errorMsg;
+      this.textarea.classList.add('expr-textarea-error');
+      // Move cursor to error position if available
+      if (pos != null && pos <= expression.length) {
+        this.textarea.setSelectionRange(pos, pos);
+      }
       this.dialog.querySelector('#btn-save-expression').disabled = true;
     }
   }
@@ -199,22 +204,29 @@ class ExpressionEditorDialog {
                 <div class="expr-help-content" id="expr-help-content" style="display: none;">
                   ${isPrecondition ? `
                     <p><strong>Precondition (Guard):</strong> A boolean expression that must be <code>true</code> for the transition to be enabled.</p>
-                    <p><strong>Examples:</strong></p>
+                    <p><strong>Infix form:</strong></p>
                     <ul>
                       <li><code>counter > 0</code> - Enable when counter is positive</li>
-                      <li><code>x >= 5 && y < 10</code> - Enable when x ≥ 5 AND y < 10</li>
-                      <li><code>status === "ready"</code> - Enable when status equals "ready"</li>
+                      <li><code>x >= 5 and y < 10</code> - Enable when x &ge; 5 AND y &lt; 10</li>
+                      <li><code>status = 1 or status = 2</code> - Enable for status 1 or 2</li>
                     </ul>
+                    <p><strong>SMT prefix form:</strong></p>
+                    <ul>
+                      <li><code>(and (> x 0) (= y 1))</code></li>
+                      <li><code>(or (< x 5) (>= y 10))</code></li>
+                    </ul>
+                    <p><strong>Operators:</strong> =, distinct, &lt;, &le;, &gt;, &ge;, and, or, not, =&gt;</p>
                   ` : `
-                    <p><strong>Postcondition (Updates):</strong> Defines how variables change when the transition fires.</p>
-                    <p><strong>Direct Assignment:</strong> Use <code>variable' = expression;</code></p>
-                    <p><strong>Constraint-based:</strong> Use <code>variable' > expr; variable' < expr;</code> (solver finds valid value)</p>
+                    <p><strong>Postcondition (Updates):</strong> Defines how variables change when the transition fires. Use primed variables (<code>x'</code>) for next-state values.</p>
+                    <p><strong>Direct Assignment:</strong> <code>x' = expression</code></p>
+                    <p><strong>Constraint-based:</strong> <code>x' > expr and x' &lt; expr</code> (solver finds valid value)</p>
                     <p><strong>Examples:</strong></p>
                     <ul>
-                      <li><code>counter' = counter + 1;</code> - Increment counter</li>
-                      <li><code>x' = x * 2; y' = y - 1;</code> - Double x and decrement y</li>
-                      <li><code>n' > n; n' < n + 10;</code> - n increases by 1-9 (random)</li>
+                      <li><code>counter' = counter + 1</code> - Increment counter</li>
+                      <li><code>x' = x * 2 and y' = y - 1</code> - Double x, decrement y</li>
+                      <li><code>n' > n and n' &lt; n + 10</code> - n increases by 1-9</li>
                     </ul>
+                    <p>Use <code>and</code> to combine multiple assignments/constraints.</p>
                   `}
                 </div>
               </div>
@@ -223,7 +235,7 @@ class ExpressionEditorDialog {
               <div class="expr-input-section">
                 <label for="expr-textarea">Expression</label>
                 <textarea id="expr-textarea" class="expr-textarea" rows="8" 
-                          placeholder="${isPrecondition ? 'e.g., counter > 0 && status === \"ready\"' : 'e.g., counter\' = counter + 1;'}">${this.escapeHtml(this.currentExpression)}</textarea>
+                          placeholder="${isPrecondition ? 'e.g., counter > 0 and status = 1' : 'e.g., counter\' = counter + 1'}">${this.escapeHtml(this.currentExpression)}</textarea>
                 <div class="expr-validation">
                   <span id="expr-validation-status" class="expr-validation-status"></span>
                   <span id="expr-validation-message" class="expr-validation-message"></span>
@@ -279,16 +291,18 @@ class ExpressionEditorDialog {
                 <div class="expr-template-buttons">
                   ${isPrecondition ? `
                     <button type="button" class="expr-template-btn" data-template="var > 0">var > 0</button>
-                    <button type="button" class="expr-template-btn" data-template="var === value">var === value</button>
+                    <button type="button" class="expr-template-btn" data-template="var = value">var = value</button>
                     <button type="button" class="expr-template-btn" data-template="var1 > var2">var1 > var2</button>
-                    <button type="button" class="expr-template-btn" data-template="cond1 && cond2">cond1 && cond2</button>
-                    <button type="button" class="expr-template-btn" data-template="cond1 || cond2">cond1 || cond2</button>
+                    <button type="button" class="expr-template-btn" data-template="cond1 and cond2">cond1 and cond2</button>
+                    <button type="button" class="expr-template-btn" data-template="cond1 or cond2">cond1 or cond2</button>
+                    <button type="button" class="expr-template-btn" data-template="(and (> var 0) (= var2 1))">(and (> ..) (= ..))</button>
                   ` : `
-                    <button type="button" class="expr-template-btn" data-template="var' = var + 1;">var' = var + 1;</button>
-                    <button type="button" class="expr-template-btn" data-template="var' = var - 1;">var' = var - 1;</button>
-                    <button type="button" class="expr-template-btn" data-template="var' = 0;">var' = 0;</button>
-                    <button type="button" class="expr-template-btn" data-template="var' > var; var' < var + 10;">var' ∈ (var, var+10)</button>
-                    <button type="button" class="expr-template-btn" data-template="var' >= 0; var' <= 100;">var' ∈ [0, 100]</button>
+                    <button type="button" class="expr-template-btn" data-template="var' = var + 1">var' = var + 1</button>
+                    <button type="button" class="expr-template-btn" data-template="var' = var - 1">var' = var - 1</button>
+                    <button type="button" class="expr-template-btn" data-template="var' = 0">var' = 0</button>
+                    <button type="button" class="expr-template-btn" data-template="x' = x + 1 and y' = y - 1">x' = .. and y' = ..</button>
+                    <button type="button" class="expr-template-btn" data-template="var' > var and var' < var + 10">var' &isin; (var, var+10)</button>
+                    <button type="button" class="expr-template-btn" data-template="var' >= 0 and var' <= 100">var' &isin; [0, 100]</button>
                   `}
                 </div>
               </div>
@@ -590,7 +604,7 @@ class DataPetriNetUI {
                   ${transition.postcondition ? `<button id="btn-clear-postcondition" type="button" class="expr-clear-btn" ${disabledAttr} title="Clear expression">✕</button>` : ''}
                 </div>
               </div>
-              <small>Format: variable' = expression; (use ' for new values)</small>
+              <small>Format: variable' = expression (use ' for new values, <code>and</code> to combine)</small>
             </div>
           `;
           
@@ -964,10 +978,9 @@ showAddVariableDialog() {
         <div class="form-group">
           <label for="variable-type">Type</label>
           <select id="variable-type">
-            <option value="int">Integer</option>
-            <option value="float">Float</option>
-            <option value="string">String</option>
-            <option value="boolean">Boolean</option>
+            <option value="int">Integer (Int)</option>
+            <option value="real">Real</option>
+            <option value="bool">Boolean (Bool)</option>
           </select>
         </div>
         <div class="form-group">
@@ -999,13 +1012,10 @@ showAddVariableDialog() {
       case 'int':
         inputHtml = '<input type="number" id="variable-initial-value" step="1" placeholder="Enter an integer">';
         break;
-      case 'float':
-        inputHtml = '<input type="number" id="variable-initial-value" step="any" placeholder="Enter a decimal number">';
+      case 'real':
+        inputHtml = '<input type="number" id="variable-initial-value" step="any" placeholder="Enter a real number">';
         break;
-      case 'string':
-        inputHtml = '<input type="text" id="variable-initial-value" placeholder="Enter text">';
-        break;
-      case 'boolean':
+      case 'bool':
         inputHtml = `
           <select id="variable-initial-value">
             <option value="">Select a value</option>
@@ -1082,7 +1092,7 @@ showAddVariableDialog() {
           if (isNaN(initialValue)) {
             throw new Error('Not a valid float');
           }
-        } else if (type === 'boolean') {
+        } else if (type === 'bool') {
           if (initialValueStr === 'true') {
             initialValue = true;
           } else if (initialValueStr === 'false') {
@@ -1090,8 +1100,6 @@ showAddVariableDialog() {
           } else {
             throw new Error('Boolean must be true or false');
           }
-        } else { // string
-          initialValue = initialValueStr;
         }
       } catch (error) {
         alert(`Invalid initial value: ${error.message}`);
@@ -1141,10 +1149,9 @@ showAddVariableDialog() {
           <div class="form-group">
             <label for="variable-type">Type</label>
             <select id="variable-type">
-              <option value="int" ${variable.type === 'int' ? 'selected' : ''}>Integer</option>
-              <option value="float" ${variable.type === 'float' ? 'selected' : ''}>Float</option>
-              <option value="string" ${variable.type === 'string' ? 'selected' : ''}>String</option>
-              <option value="boolean" ${variable.type === 'boolean' ? 'selected' : ''}>Boolean</option>
+              <option value="int" ${variable.type === 'int' ? 'selected' : ''}>Integer (Int)</option>
+              <option value="real" ${variable.type === 'real' ? 'selected' : ''}>Real</option>
+              <option value="bool" ${variable.type === 'bool' ? 'selected' : ''}>Boolean (Bool)</option>
             </select>
           </div>
           <div class="form-group">
@@ -1213,12 +1220,12 @@ showAddVariableDialog() {
             if (isNaN(parsedValue)) {
               throw new Error('Not a valid integer');
             }
-          } else if (type === 'float') {
+          } else if (type === 'real') {
             parsedValue = parseFloat(valueStr);
             if (isNaN(parsedValue)) {
-              throw new Error('Not a valid float');
+              throw new Error('Not a valid real number');
             }
-          } else if (type === 'boolean') {
+          } else if (type === 'bool') {
             if (valueStr.toLowerCase() === 'true') {
               parsedValue = true;
             } else if (valueStr.toLowerCase() === 'false') {
@@ -1226,8 +1233,6 @@ showAddVariableDialog() {
             } else {
               throw new Error('Boolean must be true or false');
             }
-          } else { // string
-            parsedValue = valueStr;
           }
         } catch (error) {
           alert(`Invalid value: ${error.message}`);
@@ -1318,12 +1323,12 @@ showAddVariableDialog() {
             if (isNaN(parsedValue)) {
               throw new Error('Not a valid integer');
             }
-          } else if (variable.type === 'float') {
+          } else if (variable.type === 'real') {
             parsedValue = parseFloat(valueStr);
             if (isNaN(parsedValue)) {
-              throw new Error('Not a valid float');
+              throw new Error('Not a valid real number');
             }
-          } else if (variable.type === 'boolean') {
+          } else if (variable.type === 'bool') {
             if (valueStr.toLowerCase() === 'true') {
               parsedValue = true;
             } else if (valueStr.toLowerCase() === 'false') {
@@ -1331,8 +1336,6 @@ showAddVariableDialog() {
             } else {
               throw new Error('Boolean must be true or false');
             }
-          } else { // string
-            parsedValue = valueStr;
           }
         } catch (error) {
           alert(`Invalid value: ${error.message}`);

--- a/src/extensions/guard-language/guard-evaluator.js
+++ b/src/extensions/guard-language/guard-evaluator.js
@@ -1,0 +1,369 @@
+/**
+ * Guard Language Evaluator
+ * Evaluates guard expression ASTs against a data valuation.
+ * Replaces the old `new Function()` approach with safe tree-walking evaluation.
+ */
+
+import { NodeType } from './guard-parser.js';
+
+/**
+ * Evaluation error with optional position
+ */
+export class EvalError extends Error {
+  constructor(message, pos) {
+    super(message);
+    this.name = 'EvalError';
+    this.pos = pos;
+  }
+}
+
+// ─── Precondition Evaluation ──────────────────────────────────────────────
+
+/**
+ * Evaluate a precondition AST against the current data valuation.
+ * All identifiers refer to current-state values.
+ *
+ * @param {Object|null} ast - Parsed AST (null = trivially true)
+ * @param {Object} valuation - Map of variable names to current values
+ * @returns {boolean} Whether the precondition is satisfied
+ */
+export function evaluatePrecondition(ast, valuation) {
+  if (ast === null) return true;
+  const result = evaluate(ast, valuation, {});
+  return Boolean(result);
+}
+
+// ─── Postcondition Evaluation ─────────────────────────────────────────────
+
+/**
+ * Analyze a postcondition AST and extract direct assignments and constraints.
+ *
+ * In postconditions:
+ * - `x' = expr` is a direct assignment (x is written to the value of expr)
+ * - `x' > expr` or any other relation involving primed vars is a constraint
+ * - Conjunctions (`and`) of assignments/constraints are decomposed
+ *
+ * @param {Object|null} ast - Parsed postcondition AST
+ * @param {Object} valuation - Current data valuation { varName: value }
+ * @returns {{ assignments: Map<string, *>, constraints: Object[] }}
+ *   - assignments: Map from variable name to the computed new value
+ *   - constraints: Array of AST nodes representing constraint expressions
+ */
+export function evaluatePostcondition(ast, valuation) {
+  if (ast === null) {
+    return { assignments: new Map(), constraints: [] };
+  }
+
+  const assignments = new Map();
+  const constraints = [];
+
+  // Decompose the AST into individual assignment/constraint clauses
+  const clauses = flattenConjunction(ast);
+
+  for (const clause of clauses) {
+    const assignment = tryExtractAssignment(clause);
+    if (assignment) {
+      // Direct assignment: x' = expr → evaluate expr in current valuation
+      const { varName, rhsAst } = assignment;
+      const value = evaluate(rhsAst, valuation, {});
+      assignments.set(varName, value);
+    } else {
+      // It's a constraint — collect it
+      constraints.push(clause);
+    }
+  }
+
+  return { assignments, constraints };
+}
+
+/**
+ * Check if a candidate value satisfies a constraint AST.
+ * Used by the WebPPL solver fallback for constraint-based postconditions.
+ *
+ * @param {Object} constraintAst - A constraint AST node
+ * @param {Object} readValuation - Current-state (read) variable values
+ * @param {Object} writeValuation - Candidate next-state values for primed variables
+ * @returns {boolean}
+ */
+export function checkConstraint(constraintAst, readValuation, writeValuation) {
+  const result = evaluate(constraintAst, readValuation, writeValuation);
+  return Boolean(result);
+}
+
+/**
+ * Extract the set of primed (written) variable names from an AST.
+ *
+ * @param {Object|null} ast - AST to analyze
+ * @returns {Set<string>} Set of variable names that appear primed
+ */
+export function getWrittenVariables(ast) {
+  const written = new Set();
+  if (!ast) return written;
+  collectPrimedVars(ast, written);
+  return written;
+}
+
+/**
+ * Convert a constraint AST to a JavaScript expression string
+ * for use with the WebPPL solver. Primed variables are expressed
+ * as the variable name without prime (since WebPPL samples them).
+ *
+ * @param {Object} ast - Constraint AST node
+ * @returns {string} JavaScript-like expression string
+ */
+export function constraintToString(ast) {
+  return astToInfix(ast);
+}
+
+// ─── Core Evaluation Engine ──────────────────────────────────────────────
+
+/**
+ * Recursively evaluate an AST node.
+ *
+ * @param {Object} node - AST node
+ * @param {Object} readVals - Current-state variable values (ident without prime)
+ * @param {Object} writeVals - Next-state variable values (ident with prime)
+ * @returns {*} The evaluated result (number, boolean, etc.)
+ */
+function evaluate(node, readVals, writeVals) {
+  switch (node.type) {
+    case NodeType.LITERAL:
+      return node.value;
+
+    case NodeType.VAR:
+      if (node.primed) {
+        if (node.name in writeVals) return writeVals[node.name];
+        if (node.name in readVals) return readVals[node.name];
+        throw new EvalError(`Primed variable '${node.name}'' has no value`);
+      }
+      if (node.name in readVals) return readVals[node.name];
+      throw new EvalError(`Variable '${node.name}' is not defined`);
+
+    case NodeType.BINOP:
+      return evalBinop(node, readVals, writeVals);
+
+    case NodeType.UNARYOP:
+      return evalUnary(node, readVals, writeVals);
+
+    case NodeType.CALL:
+      return evalCall(node, readVals, writeVals);
+
+    case NodeType.QUANTIFIER:
+      throw new EvalError(
+        `Quantifier '${node.kind}' cannot be evaluated at runtime — ` +
+        `quantifiers are only used in the SMT verification path`
+      );
+
+    case NodeType.LET_EXPR: {
+      const extendedRead = { ...readVals };
+      for (const binding of node.bindings) {
+        extendedRead[binding.name] = evaluate(binding.expr, readVals, writeVals);
+      }
+      return evaluate(node.body, extendedRead, writeVals);
+    }
+
+    default:
+      throw new EvalError(`Unknown AST node type: ${node.type}`);
+  }
+}
+
+function evalBinop(node, readVals, writeVals) {
+  const l = evaluate(node.left, readVals, writeVals);
+  const r = evaluate(node.right, readVals, writeVals);
+
+  switch (node.op) {
+    case 'and':      return Boolean(l) && Boolean(r);
+    case 'or':       return Boolean(l) || Boolean(r);
+    case '=>':       return !Boolean(l) || Boolean(r);
+    case '=':        return l === r;
+    case 'distinct': return l !== r;
+    case '<':        return l < r;
+    case '<=':       return l <= r;
+    case '>':        return l > r;
+    case '>=':       return l >= r;
+    case '+':        return Number(l) + Number(r);
+    case '-':        return Number(l) - Number(r);
+    case '*':        return Number(l) * Number(r);
+    case '/':
+      if (Number(r) === 0) throw new EvalError('Division by zero');
+      return Number(l) / Number(r);
+    default:
+      throw new EvalError(`Unknown binary operator: ${node.op}`);
+  }
+}
+
+function evalUnary(node, readVals, writeVals) {
+  const v = evaluate(node.operand, readVals, writeVals);
+  switch (node.op) {
+    case 'not': return !Boolean(v);
+    case '-':   return -Number(v);
+    default:
+      throw new EvalError(`Unknown unary operator: ${node.op}`);
+  }
+}
+
+function evalCall(node, readVals, writeVals) {
+  const args = node.args.map(a => evaluate(a, readVals, writeVals));
+
+  switch (node.op) {
+    case 'and':
+      return args.every(a => Boolean(a));
+    case 'or':
+      return args.some(a => Boolean(a));
+    case 'not':
+      return !Boolean(args[0]);
+    case '=>':
+      return !Boolean(args[0]) || Boolean(args[1]);
+    case 'ite':
+      return Boolean(args[0]) ? args[1] : args[2];
+    case '=':
+      return args.every((a, i) => i === 0 || a === args[0]);
+    case 'distinct':
+      // All pairwise distinct
+      for (let i = 0; i < args.length; i++) {
+        for (let j = i + 1; j < args.length; j++) {
+          if (args[i] === args[j]) return false;
+        }
+      }
+      return true;
+    case '<':  return args[0] < args[1];
+    case '<=': return args[0] <= args[1];
+    case '>':  return args[0] > args[1];
+    case '>=': return args[0] >= args[1];
+    case '+':  return args.reduce((a, b) => Number(a) + Number(b), 0);
+    case '-':
+      if (args.length === 1) return -Number(args[0]);
+      return args.reduce((a, b) => Number(a) - Number(b));
+    case '*':  return args.reduce((a, b) => Number(a) * Number(b), 1);
+    case '/':
+      if (args.length < 2) throw new EvalError(`'/' requires at least 2 arguments`);
+      return args.reduce((a, b) => {
+        if (Number(b) === 0) throw new EvalError('Division by zero');
+        return Number(a) / Number(b);
+      });
+    default:
+      throw new EvalError(`Unknown SMT operator: ${node.op}`);
+  }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Flatten nested `and` / BinOp('and') into a flat list of clauses.
+ */
+function flattenConjunction(node) {
+  if (node.type === NodeType.BINOP && node.op === 'and') {
+    return [...flattenConjunction(node.left), ...flattenConjunction(node.right)];
+  }
+  if (node.type === NodeType.CALL && node.op === 'and') {
+    return node.args.flatMap(a => flattenConjunction(a));
+  }
+  return [node];
+}
+
+/**
+ * Try to extract a direct assignment from a clause:
+ *   x' = expr  →  { varName: 'x', rhsAst: expr }
+ * Returns null if the clause is not a simple assignment.
+ */
+function tryExtractAssignment(node) {
+  // BinOp('=', Var(x, primed=true), rhs) or Call('=', [Var(x, primed=true), rhs])
+  if (node.type === NodeType.BINOP && node.op === '=') {
+    if (node.left.type === NodeType.VAR && node.left.primed) {
+      return { varName: node.left.name, rhsAst: node.right };
+    }
+  }
+  if (node.type === NodeType.CALL && node.op === '=' && node.args.length === 2) {
+    if (node.args[0].type === NodeType.VAR && node.args[0].primed) {
+      return { varName: node.args[0].name, rhsAst: node.args[1] };
+    }
+  }
+  return null;
+}
+
+/**
+ * Recursively collect all primed variable names from an AST.
+ */
+function collectPrimedVars(node, set) {
+  if (!node) return;
+  switch (node.type) {
+    case NodeType.VAR:
+      if (node.primed) set.add(node.name);
+      break;
+    case NodeType.BINOP:
+      collectPrimedVars(node.left, set);
+      collectPrimedVars(node.right, set);
+      break;
+    case NodeType.UNARYOP:
+      collectPrimedVars(node.operand, set);
+      break;
+    case NodeType.CALL:
+      for (const arg of node.args) collectPrimedVars(arg, set);
+      break;
+    case NodeType.QUANTIFIER:
+      collectPrimedVars(node.body, set);
+      break;
+    case NodeType.LET_EXPR:
+      for (const b of node.bindings) collectPrimedVars(b.expr, set);
+      collectPrimedVars(node.body, set);
+      break;
+  }
+}
+
+/**
+ * Convert an AST node to an infix JavaScript-like string.
+ * Used for passing constraints to the WebPPL solver.
+ */
+function astToInfix(node) {
+  if (!node) return 'true';
+
+  switch (node.type) {
+    case NodeType.LITERAL:
+      return String(node.value);
+
+    case NodeType.VAR:
+      // For constraint evaluation, primed vars become unprimed
+      // (the solver samples the primed var's value)
+      return node.name;
+
+    case NodeType.BINOP: {
+      const l = astToInfix(node.left);
+      const r = astToInfix(node.right);
+      const jsOp = node.op === '=' ? '==' : node.op === 'distinct' ? '!=' : node.op;
+      if (['and', 'or'].includes(node.op)) {
+        const sym = node.op === 'and' ? '&&' : '||';
+        return `(${l} ${sym} ${r})`;
+      }
+      return `(${l} ${jsOp} ${r})`;
+    }
+
+    case NodeType.UNARYOP:
+      if (node.op === 'not') return `!(${astToInfix(node.operand)})`;
+      if (node.op === '-') return `(-(${astToInfix(node.operand)}))`;
+      return `${node.op}(${astToInfix(node.operand)})`;
+
+    case NodeType.CALL: {
+      const args = node.args.map(a => astToInfix(a));
+      if (node.op === 'and') return args.map(a => `(${a})`).join(' && ');
+      if (node.op === 'or') return args.map(a => `(${a})`).join(' || ');
+      if (node.op === 'not') return `!(${args[0]})`;
+      if (node.op === 'ite') return `(${args[0]} ? ${args[1]} : ${args[2]})`;
+      if (node.op === '=>') return `(!(${args[0]}) || (${args[1]}))`;
+      if (node.op === '=') return args.map((a, i) => i === 0 ? a : `(${args[0]} == ${a})`).slice(1).join(' && ');
+      if (node.op === 'distinct') return `(${args[0]} != ${args[1]})`;
+      // Arithmetic
+      if (['+', '-', '*', '/'].includes(node.op)) {
+        if (args.length === 1 && node.op === '-') return `(-(${args[0]}))`;
+        return args.reduce((acc, a) => `(${acc} ${node.op} ${a})`);
+      }
+      // Comparisons
+      if (['<', '<=', '>', '>='].includes(node.op)) {
+        return `(${args[0]} ${node.op} ${args[1]})`;
+      }
+      return args.join(` ${node.op} `);
+    }
+
+    default:
+      return 'true';
+  }
+}

--- a/src/extensions/guard-language/guard-lexer.js
+++ b/src/extensions/guard-language/guard-lexer.js
@@ -1,0 +1,314 @@
+/**
+ * Guard Language Lexer
+ * Tokenizes guard expressions (preconditions/postconditions) for Data Petri Nets.
+ * Supports both SMT-LIB2 prefix form and restricted infix form.
+ */
+
+/** Token types */
+export const TokenType = Object.freeze({
+  // Literals
+  INTEGER:    'INTEGER',
+  REAL:       'REAL',
+  BOOL_LIT:   'BOOL_LIT',
+  IDENT:      'IDENT',
+
+  // Keywords (logical)
+  AND:        'AND',
+  OR:         'OR',
+  NOT:        'NOT',
+  IMPLIES:    'IMPLIES',     // =>
+  ITE:        'ITE',
+  DISTINCT:   'DISTINCT',
+  EXISTS:     'EXISTS',
+  FORALL:     'FORALL',
+  LET:        'LET',
+
+  // Comparison operators
+  EQ:         'EQ',          // =
+  LT:         'LT',          // <
+  LE:         'LE',          // <=
+  GT:         'GT',          // >
+  GE:         'GE',          // >=
+
+  // Arithmetic operators
+  PLUS:       'PLUS',        // +
+  MINUS:      'MINUS',       // -
+  STAR:       'STAR',        // *
+  SLASH:      'SLASH',       // /
+
+  // Delimiters
+  LPAREN:     'LPAREN',      // (
+  RPAREN:     'RPAREN',      // )
+
+  // Prime
+  PRIME:      'PRIME',       // '
+
+  // End
+  EOF:        'EOF',
+});
+
+/** Reserved suffixes that must not be used as base variable names */
+const RESERVED_SUFFIXES = ['_r', '_w', '_prime'];
+
+/** Keyword map (case-insensitive) */
+const KEYWORDS = new Map([
+  ['and',      TokenType.AND],
+  ['or',       TokenType.OR],
+  ['not',      TokenType.NOT],
+  ['true',     TokenType.BOOL_LIT],
+  ['false',    TokenType.BOOL_LIT],
+  ['ite',      TokenType.ITE],
+  ['distinct', TokenType.DISTINCT],
+  ['exists',   TokenType.EXISTS],
+  ['forall',   TokenType.FORALL],
+  ['let',      TokenType.LET],
+]);
+
+/**
+ * A single token produced by the lexer
+ */
+export class Token {
+  /**
+   * @param {string} type - TokenType value
+   * @param {string} value - Raw string value
+   * @param {number} pos - 0-based character offset in the input
+   */
+  constructor(type, value, pos) {
+    this.type = type;
+    this.value = value;
+    this.pos = pos;
+  }
+}
+
+/**
+ * Lexer error with position information
+ */
+export class LexerError extends Error {
+  /**
+   * @param {string} message - Error description
+   * @param {number} pos - 0-based character offset where the error occurred
+   */
+  constructor(message, pos) {
+    super(message);
+    this.name = 'LexerError';
+    this.pos = pos;
+  }
+}
+
+/**
+ * Tokenize a guard expression string.
+ *
+ * @param {string} input - The expression to tokenize
+ * @returns {Token[]} Array of tokens (always ends with EOF)
+ * @throws {LexerError} On unrecognized characters or reserved names
+ */
+export function tokenize(input) {
+  const tokens = [];
+  let i = 0;
+  const len = input.length;
+
+  while (i < len) {
+    const ch = input[i];
+
+    // Skip whitespace
+    if (/\s/.test(ch)) {
+      i++;
+      continue;
+    }
+
+    // Single-character tokens
+    if (ch === '(') { tokens.push(new Token(TokenType.LPAREN, '(', i)); i++; continue; }
+    if (ch === ')') { tokens.push(new Token(TokenType.RPAREN, ')', i)); i++; continue; }
+    if (ch === '*') { tokens.push(new Token(TokenType.STAR, '*', i)); i++; continue; }
+    if (ch === '/') { tokens.push(new Token(TokenType.SLASH, '/', i)); i++; continue; }
+    if (ch === "'") { tokens.push(new Token(TokenType.PRIME, "'", i)); i++; continue; }
+
+    // => (implies)
+    if (ch === '=' && i + 1 < len && input[i + 1] === '>') {
+      tokens.push(new Token(TokenType.IMPLIES, '=>', i));
+      i += 2;
+      continue;
+    }
+
+    // == normalized to = (EQ)
+    if (ch === '=' && i + 1 < len && input[i + 1] === '=') {
+      tokens.push(new Token(TokenType.EQ, '=', i));
+      i += 2;
+      continue;
+    }
+
+    // = (EQ)
+    if (ch === '=') {
+      tokens.push(new Token(TokenType.EQ, '=', i));
+      i++;
+      continue;
+    }
+
+    // != normalized to DISTINCT
+    if (ch === '!' && i + 1 < len && input[i + 1] === '=') {
+      tokens.push(new Token(TokenType.DISTINCT, 'distinct', i));
+      i += 2;
+      continue;
+    }
+
+    // <= (LE)
+    if (ch === '<' && i + 1 < len && input[i + 1] === '=') {
+      tokens.push(new Token(TokenType.LE, '<=', i));
+      i += 2;
+      continue;
+    }
+
+    // < (LT)
+    if (ch === '<') {
+      tokens.push(new Token(TokenType.LT, '<', i));
+      i++;
+      continue;
+    }
+
+    // >= (GE) — but not => (already handled above)
+    if (ch === '>' && i + 1 < len && input[i + 1] === '=') {
+      tokens.push(new Token(TokenType.GE, '>=', i));
+      i += 2;
+      continue;
+    }
+
+    // > (GT)
+    if (ch === '>') {
+      tokens.push(new Token(TokenType.GT, '>', i));
+      i++;
+      continue;
+    }
+
+    // && normalized to AND
+    if (ch === '&' && i + 1 < len && input[i + 1] === '&') {
+      tokens.push(new Token(TokenType.AND, 'and', i));
+      i += 2;
+      continue;
+    }
+
+    // || normalized to OR
+    if (ch === '|' && i + 1 < len && input[i + 1] === '|') {
+      tokens.push(new Token(TokenType.OR, 'or', i));
+      i += 2;
+      continue;
+    }
+
+    // + / - : could be operator or part of a number
+    if (ch === '+' || ch === '-') {
+      // Check if this is a sign for a number (not preceded by a value token)
+      const prevToken = tokens.length > 0 ? tokens[tokens.length - 1] : null;
+      const isSign = !prevToken ||
+        prevToken.type === TokenType.LPAREN ||
+        prevToken.type === TokenType.EQ ||
+        prevToken.type === TokenType.LT ||
+        prevToken.type === TokenType.LE ||
+        prevToken.type === TokenType.GT ||
+        prevToken.type === TokenType.GE ||
+        prevToken.type === TokenType.DISTINCT ||
+        prevToken.type === TokenType.PLUS ||
+        prevToken.type === TokenType.MINUS ||
+        prevToken.type === TokenType.STAR ||
+        prevToken.type === TokenType.SLASH ||
+        prevToken.type === TokenType.AND ||
+        prevToken.type === TokenType.OR ||
+        prevToken.type === TokenType.NOT ||
+        prevToken.type === TokenType.IMPLIES ||
+        prevToken.type === TokenType.ITE;
+
+      if (isSign && i + 1 < len && /\d/.test(input[i + 1])) {
+        // Signed number
+        const start = i;
+        i++; // skip sign
+        const numToken = readNumber(input, i, start);
+        tokens.push(numToken);
+        i = start + numToken.value.length;
+        continue;
+      }
+
+      // Otherwise it's an operator
+      if (ch === '+') {
+        tokens.push(new Token(TokenType.PLUS, '+', i));
+      } else {
+        tokens.push(new Token(TokenType.MINUS, '-', i));
+      }
+      i++;
+      continue;
+    }
+
+    // Numbers
+    if (/\d/.test(ch)) {
+      const numToken = readNumber(input, i, i);
+      tokens.push(numToken);
+      i += numToken.value.length;
+      continue;
+    }
+
+    // Identifiers and keywords
+    if (/[a-zA-Z_]/.test(ch)) {
+      const start = i;
+      while (i < len && /[a-zA-Z0-9_]/.test(input[i])) {
+        i++;
+      }
+      const word = input.slice(start, i);
+      const lower = word.toLowerCase();
+
+      // Check for reserved suffixes on base variable names
+      for (const suffix of RESERVED_SUFFIXES) {
+        if (lower.endsWith(suffix) && lower !== suffix) {
+          throw new LexerError(
+            `Identifier "${word}" uses reserved suffix "${suffix}". ` +
+            `Names ending in _r, _w, or _prime are reserved for internal use.`,
+            start
+          );
+        }
+      }
+
+      // Check for keyword
+      const kwType = KEYWORDS.get(lower);
+      if (kwType) {
+        if (kwType === TokenType.BOOL_LIT) {
+          tokens.push(new Token(TokenType.BOOL_LIT, lower, start));
+        } else {
+          tokens.push(new Token(kwType, lower, start));
+        }
+      } else {
+        tokens.push(new Token(TokenType.IDENT, word, start));
+      }
+      continue;
+    }
+
+    throw new LexerError(`Unexpected character '${ch}'`, i);
+  }
+
+  tokens.push(new Token(TokenType.EOF, '', len));
+  return tokens;
+}
+
+/**
+ * Read a number (integer or real) starting at position `i` in `input`.
+ * @param {string} input
+ * @param {number} i - Position of first digit
+ * @param {number} tokenStart - Position of the token start (may include sign)
+ * @returns {Token}
+ */
+function readNumber(input, i, tokenStart) {
+  let end = i;
+  const len = input.length;
+
+  while (end < len && /\d/.test(input[end])) {
+    end++;
+  }
+
+  // Check for decimal point
+  if (end < len && input[end] === '.' && end + 1 < len && /\d/.test(input[end + 1])) {
+    end++; // skip '.'
+    while (end < len && /\d/.test(input[end])) {
+      end++;
+    }
+    const value = input.slice(tokenStart, end);
+    return new Token(TokenType.REAL, value, tokenStart);
+  }
+
+  const value = input.slice(tokenStart, end);
+  return new Token(TokenType.INTEGER, value, tokenStart);
+}

--- a/src/extensions/guard-language/guard-migrator.js
+++ b/src/extensions/guard-language/guard-migrator.js
@@ -1,0 +1,160 @@
+/**
+ * Guard Language Migrator
+ * Converts old JavaScript-style guard expressions to the new guard language syntax.
+ * Applied automatically when loading DPN JSON files with legacy expressions.
+ */
+
+/**
+ * Migrate a precondition expression from old JavaScript syntax to the new guard language.
+ *
+ * Conversions:
+ * - `===` → `=`
+ * - `==` → `=`
+ * - `!==` → `distinct`  (but != is also accepted by lexer)
+ * - `&&` → `and`
+ * - `||` → `or`
+ * - `!expr` → `not expr`
+ * - `%` → removed (not in grammar) — will cause a parse error if present
+ * - String literals in comparisons → integer codes (logged as warning)
+ *
+ * @param {string} expression - Legacy precondition expression
+ * @returns {string} Migrated expression
+ */
+export function migratePrecondition(expression) {
+  if (!expression || !expression.trim()) return '';
+  return migrateExpression(expression);
+}
+
+/**
+ * Migrate a postcondition expression from old JavaScript syntax to the new guard language.
+ *
+ * Additional conversions for postconditions:
+ * - `;` separators → `and` conjunction
+ * - Remove trailing semicolons
+ *
+ * @param {string} expression - Legacy postcondition expression
+ * @returns {string} Migrated expression
+ */
+export function migratePostcondition(expression) {
+  if (!expression || !expression.trim()) return '';
+
+  // Split on semicolons, filter empty parts, migrate each, join with 'and'
+  const parts = expression.split(';')
+    .map(s => s.trim())
+    .filter(s => s.length > 0)
+    .map(s => migrateExpression(s));
+
+  if (parts.length === 0) return '';
+  if (parts.length === 1) return parts[0];
+  return parts.join(' and ');
+}
+
+/**
+ * Core migration: convert a single expression fragment.
+ */
+function migrateExpression(expr) {
+  let s = expr.trim();
+
+  // Replace === with = (must come before == replacement)
+  s = s.replace(/===/g, '=');
+  // Replace == with =
+  s = s.replace(/==/g, '=');
+  // Replace !== with distinct (must come before != replacement)
+  s = s.replace(/!==/g, 'distinct');
+
+  // Replace && with and (word-boundary safe)
+  s = s.replace(/&&/g, ' and ');
+  // Replace || with or
+  s = s.replace(/\|\|/g, ' or ');
+
+  // Replace prefix ! (not followed by =) with not
+  s = s.replace(/!\s*(?!=)/g, 'not ');
+
+  // Replace string literals with a warning comment
+  // "string" or 'string' → warn but keep as-is (will fail validation)
+  // Common pattern: status === "ready" → status = "ready"
+  // The user will need to manually convert string values to integer codes
+
+  // Clean up double spaces
+  s = s.replace(/\s{2,}/g, ' ').trim();
+
+  return s;
+}
+
+/**
+ * Check if an expression appears to use legacy JavaScript syntax.
+ *
+ * @param {string} expression
+ * @returns {boolean} True if the expression contains legacy syntax markers
+ */
+export function isLegacySyntax(expression) {
+  if (!expression || !expression.trim()) return false;
+  const s = expression.trim();
+  return /===|!==|&&|\|\||[^!]==[^>]/.test(s) ||  // JS operators
+         /;\s*\S/.test(s) ||                       // semicolons as separators
+         /%/.test(s) ||                             // modulo operator
+         /"[^"]*"|'[^']*'/.test(s);                // string literals
+}
+
+/**
+ * Migrate a full DPN configuration's transitions in-place.
+ * Converts all preconditions and postconditions to the new syntax.
+ *
+ * @param {Object} dpnConfig - DPN configuration object with a transitions array
+ * @returns {{ migratedCount: number, warnings: string[] }}
+ */
+export function migrateDpnConfig(dpnConfig) {
+  let migratedCount = 0;
+  const warnings = [];
+
+  if (!dpnConfig || !dpnConfig.transitions) {
+    return { migratedCount, warnings };
+  }
+
+  for (const transition of dpnConfig.transitions) {
+    if (transition.precondition && isLegacySyntax(transition.precondition)) {
+      const original = transition.precondition;
+      transition.precondition = migratePrecondition(original);
+      migratedCount++;
+
+      // Check for string literals that couldn't be auto-migrated
+      if (/"[^"]*"|'[^']*'/.test(transition.precondition)) {
+        warnings.push(
+          `Transition '${transition.label || transition.id}': precondition contains string literals ` +
+          `that should be converted to integer codes: ${transition.precondition}`
+        );
+      }
+    }
+
+    if (transition.postcondition && isLegacySyntax(transition.postcondition)) {
+      const original = transition.postcondition;
+      transition.postcondition = migratePostcondition(original);
+      migratedCount++;
+
+      if (/"[^"]*"|'[^']*'/.test(transition.postcondition)) {
+        warnings.push(
+          `Transition '${transition.label || transition.id}': postcondition contains string literals ` +
+          `that should be converted to integer codes: ${transition.postcondition}`
+        );
+      }
+    }
+  }
+
+  // Migrate data variable types
+  if (dpnConfig.dataVariables) {
+    for (const dv of dpnConfig.dataVariables) {
+      if (dv.type === 'float' || dv.type === 'number') {
+        dv.type = dv.type === 'float' ? 'real' : 'int';
+        migratedCount++;
+      }
+      if (dv.type === 'string') {
+        warnings.push(
+          `Variable '${dv.name}': type 'string' is not supported in the new guard language. ` +
+          `Please convert to integer codes.`
+        );
+      }
+    }
+  }
+
+  return { migratedCount, warnings };
+}

--- a/src/extensions/guard-language/guard-parser.js
+++ b/src/extensions/guard-language/guard-parser.js
@@ -1,0 +1,576 @@
+/**
+ * Guard Language Parser
+ * Parses tokenized guard expressions into an AST.
+ * Supports both SMT-LIB2 prefix form and restricted infix form.
+ * The two forms may not be mixed within a single expression.
+ */
+
+import { tokenize, TokenType, LexerError } from './guard-lexer.js';
+
+// ─── AST Node Types ───────────────────────────────────────────────────────
+
+/** AST node types */
+export const NodeType = Object.freeze({
+  LITERAL:    'Literal',      // { sort: 'Int'|'Real'|'Bool', value }
+  VAR:        'Var',          // { name, primed: boolean }
+  BINOP:      'BinOp',        // { op, left, right }
+  UNARYOP:    'UnaryOp',      // { op, operand }
+  CALL:       'Call',         // { op, args: [] }  — SMT multi-arg ops
+  QUANTIFIER: 'Quantifier',   // { kind: 'exists'|'forall', bindings: [{name,sort}], body }
+  LET_EXPR:   'Let',          // { bindings: [{name,expr}], body }
+});
+
+/** Create a literal node */
+export function litNode(sort, value) {
+  return { type: NodeType.LITERAL, sort, value };
+}
+
+/** Create a variable reference node */
+export function varNode(name, primed = false) {
+  return { type: NodeType.VAR, name, primed };
+}
+
+/** Create a binary operation node */
+export function binopNode(op, left, right) {
+  return { type: NodeType.BINOP, op, left, right };
+}
+
+/** Create a unary operation node */
+export function unaryNode(op, operand) {
+  return { type: NodeType.UNARYOP, op, operand };
+}
+
+/** Create a multi-argument call node (SMT ops like and, or, +, -, etc.) */
+export function callNode(op, args) {
+  return { type: NodeType.CALL, op, args };
+}
+
+/** Create a quantifier node */
+export function quantifierNode(kind, bindings, body) {
+  return { type: NodeType.QUANTIFIER, kind, bindings, body };
+}
+
+/** Create a let expression node */
+export function letNode(bindings, body) {
+  return { type: NodeType.LET_EXPR, bindings, body };
+}
+
+// ─── Parse Error ──────────────────────────────────────────────────────────
+
+export class ParseError extends Error {
+  /**
+   * @param {string} message
+   * @param {number} pos - 0-based character offset in the input
+   */
+  constructor(message, pos) {
+    super(message);
+    this.name = 'ParseError';
+    this.pos = pos;
+  }
+}
+
+// ─── SMT Operators with Arity Constraints ─────────────────────────────────
+
+/**
+ * Arity map for SMT operators: [minArgs, maxArgs].
+ * null for maxArgs means unbounded.
+ */
+const SMT_ARITY = new Map([
+  ['and',      [1, null]],
+  ['or',       [1, null]],
+  ['not',      [1, null]],   // not: ≥1 (spec says ≥1)
+  ['+',        [1, null]],
+  ['-',        [1, null]],
+  ['*',        [2, null]],
+  ['/',        [2, null]],
+  ['=>',       [2, null]],
+  ['=',        [2, null]],
+  ['distinct', [2, null]],
+  ['<',        [2, null]],
+  ['<=',       [2, null]],
+  ['>',        [2, null]],
+  ['>=',       [2, null]],
+  ['ite',      [3, 3]],
+]);
+
+/** Set of all valid SMT operator names */
+const SMT_OPS = new Set(SMT_ARITY.keys());
+// Add quantifiers and let (handled separately)
+SMT_OPS.add('exists');
+SMT_OPS.add('forall');
+SMT_OPS.add('let');
+
+// ─── Parser Class ─────────────────────────────────────────────────────────
+
+class Parser {
+  /**
+   * @param {import('./guard-lexer.js').Token[]} tokens
+   * @param {boolean} isPostcondition - Whether primed variables are allowed
+   */
+  constructor(tokens, isPostcondition) {
+    this.tokens = tokens;
+    this.pos = 0;
+    this.isPostcondition = isPostcondition;
+  }
+
+  /** Current token */
+  peek() {
+    return this.tokens[this.pos];
+  }
+
+  /** Consume and return current token */
+  advance() {
+    const tok = this.tokens[this.pos];
+    this.pos++;
+    return tok;
+  }
+
+  /** Expect a specific token type, consume and return it, or throw */
+  expect(type) {
+    const tok = this.peek();
+    if (tok.type !== type) {
+      throw new ParseError(
+        `Expected ${type} but got ${tok.type} ('${tok.value}')`,
+        tok.pos
+      );
+    }
+    return this.advance();
+  }
+
+  /** Check if current token is of a given type */
+  check(type) {
+    return this.peek().type === type;
+  }
+
+  /** Check if current token matches a type and value */
+  checkValue(type, value) {
+    const tok = this.peek();
+    return tok.type === type && tok.value === value;
+  }
+
+  // ─── Top-level dispatch ───────────────────────────────────────────────
+
+  /**
+   * Parse the full expression.
+   * If the first non-whitespace token is '(', parse as SMT prefix form.
+   * Otherwise, parse as infix form.
+   */
+  parseExpression() {
+    if (this.check(TokenType.EOF)) {
+      return null; // empty expression
+    }
+
+    let ast;
+    if (this.check(TokenType.LPAREN)) {
+      ast = this.parseSmt();
+    } else {
+      ast = this.parseDisjunction();
+    }
+
+    // Must consume all tokens
+    if (!this.check(TokenType.EOF)) {
+      const tok = this.peek();
+      throw new ParseError(
+        `Unexpected token '${tok.value}' after end of expression`,
+        tok.pos
+      );
+    }
+
+    return ast;
+  }
+
+  // ─── SMT-LIB2 Prefix Parser ──────────────────────────────────────────
+
+  /**
+   * Parse an SMT s-expression: (op arg1 arg2 ...) | ident | number | bool_lit
+   */
+  parseSmt() {
+    const tok = this.peek();
+
+    if (tok.type === TokenType.LPAREN) {
+      return this.parseSmtApplication();
+    }
+    if (tok.type === TokenType.IDENT) {
+      return this.parseSmtAtom();
+    }
+    if (tok.type === TokenType.INTEGER || tok.type === TokenType.REAL) {
+      return this.parseSmtNumber();
+    }
+    if (tok.type === TokenType.BOOL_LIT) {
+      return this.parseSmtBoolLit();
+    }
+    // Allow + or - as prefix for numbers inside SMT forms
+    if (tok.type === TokenType.PLUS || tok.type === TokenType.MINUS) {
+      return this.parseSmtNumber();
+    }
+
+    throw new ParseError(
+      `Unexpected token '${tok.value}' in SMT expression`,
+      tok.pos
+    );
+  }
+
+  /** Parse (op args...) in SMT prefix form */
+  parseSmtApplication() {
+    const lp = this.expect(TokenType.LPAREN);
+
+    const opTok = this.peek();
+
+    // Determine the operator
+    let op;
+    if (opTok.type === TokenType.AND)      op = 'and';
+    else if (opTok.type === TokenType.OR)   op = 'or';
+    else if (opTok.type === TokenType.NOT)  op = 'not';
+    else if (opTok.type === TokenType.IMPLIES) op = '=>';
+    else if (opTok.type === TokenType.ITE)  op = 'ite';
+    else if (opTok.type === TokenType.DISTINCT) op = 'distinct';
+    else if (opTok.type === TokenType.EXISTS) op = 'exists';
+    else if (opTok.type === TokenType.FORALL) op = 'forall';
+    else if (opTok.type === TokenType.LET)  op = 'let';
+    else if (opTok.type === TokenType.EQ)   op = '=';
+    else if (opTok.type === TokenType.LT)   op = '<';
+    else if (opTok.type === TokenType.LE)   op = '<=';
+    else if (opTok.type === TokenType.GT)   op = '>';
+    else if (opTok.type === TokenType.GE)   op = '>=';
+    else if (opTok.type === TokenType.PLUS) op = '+';
+    else if (opTok.type === TokenType.MINUS) op = '-';
+    else if (opTok.type === TokenType.STAR) op = '*';
+    else if (opTok.type === TokenType.SLASH) op = '/';
+    else {
+      // Reject uninterpreted function symbols: (f ...) where f is an ident
+      // Also reject (number) forms like (10)
+      throw new ParseError(
+        `Invalid SMT operator '${opTok.value}'. Only built-in operators are allowed (and, or, not, =>, ite, distinct, =, <, <=, >, >=, +, -, *, /, exists, forall, let).`,
+        opTok.pos
+      );
+    }
+    this.advance(); // consume operator
+
+    // Handle quantifiers
+    if (op === 'exists' || op === 'forall') {
+      return this.parseSmtQuantifier(op, lp.pos);
+    }
+
+    // Handle let
+    if (op === 'let') {
+      return this.parseSmtLet(lp.pos);
+    }
+
+    // Parse arguments
+    const args = [];
+    while (!this.check(TokenType.RPAREN) && !this.check(TokenType.EOF)) {
+      args.push(this.parseSmt());
+    }
+    this.expect(TokenType.RPAREN);
+
+    // Validate arity
+    const arity = SMT_ARITY.get(op);
+    if (arity) {
+      const [minArgs, maxArgs] = arity;
+      if (args.length < minArgs) {
+        throw new ParseError(
+          `Operator '${op}' requires at least ${minArgs} argument(s), got ${args.length}`,
+          lp.pos
+        );
+      }
+      if (maxArgs !== null && args.length > maxArgs) {
+        throw new ParseError(
+          `Operator '${op}' accepts at most ${maxArgs} argument(s), got ${args.length}`,
+          lp.pos
+        );
+      }
+    }
+
+    return callNode(op, args);
+  }
+
+  /** Parse (exists ((v1 Sort1) ...) body) */
+  parseSmtQuantifier(kind, startPos) {
+    this.expect(TokenType.LPAREN); // opening of bindings list
+
+    const bindings = [];
+    while (this.check(TokenType.LPAREN)) {
+      this.advance(); // (
+      const nameTok = this.expect(TokenType.IDENT);
+      const sortTok = this.expect(TokenType.IDENT);
+      bindings.push({ name: nameTok.value, sort: sortTok.value });
+      this.expect(TokenType.RPAREN); // )
+    }
+    this.expect(TokenType.RPAREN); // close bindings list
+
+    if (bindings.length === 0) {
+      throw new ParseError(
+        `Quantifier '${kind}' requires at least one binding`,
+        startPos
+      );
+    }
+
+    const body = this.parseSmt();
+    this.expect(TokenType.RPAREN); // close quantifier
+
+    return quantifierNode(kind, bindings, body);
+  }
+
+  /** Parse (let ((v1 expr1) ...) body) */
+  parseSmtLet(startPos) {
+    this.expect(TokenType.LPAREN); // opening of bindings list
+
+    const bindings = [];
+    while (this.check(TokenType.LPAREN)) {
+      this.advance(); // (
+      const nameTok = this.expect(TokenType.IDENT);
+      const expr = this.parseSmt();
+      bindings.push({ name: nameTok.value, expr });
+      this.expect(TokenType.RPAREN); // )
+    }
+    this.expect(TokenType.RPAREN); // close bindings list
+
+    if (bindings.length === 0) {
+      throw new ParseError(`'let' requires at least one binding`, startPos);
+    }
+
+    const body = this.parseSmt();
+    this.expect(TokenType.RPAREN); // close let
+
+    return letNode(bindings, body);
+  }
+
+  /** Parse an identifier atom, possibly with prime */
+  parseSmtAtom() {
+    const tok = this.advance();
+    // Check for prime
+    if (this.check(TokenType.PRIME)) {
+      if (!this.isPostcondition) {
+        throw new ParseError(
+          `Primed variable '${tok.value}'' is not allowed in preconditions`,
+          tok.pos
+        );
+      }
+      this.advance(); // consume '
+      return varNode(tok.value, true);
+    }
+    return varNode(tok.value, false);
+  }
+
+  /** Parse a number in SMT context */
+  parseSmtNumber() {
+    const tok = this.peek();
+    // Handle signed numbers
+    if (tok.type === TokenType.PLUS || tok.type === TokenType.MINUS) {
+      const sign = this.advance();
+      const numTok = this.peek();
+      if (numTok.type === TokenType.INTEGER || numTok.type === TokenType.REAL) {
+        this.advance();
+        const value = sign.value + numTok.value;
+        return litNode(numTok.type === TokenType.REAL ? 'Real' : 'Int',
+          numTok.type === TokenType.REAL ? parseFloat(value) : parseInt(value, 10));
+      }
+      throw new ParseError(`Expected number after '${sign.value}'`, sign.pos);
+    }
+
+    const numTok = this.advance();
+    if (numTok.type === TokenType.REAL) {
+      return litNode('Real', parseFloat(numTok.value));
+    }
+    return litNode('Int', parseInt(numTok.value, 10));
+  }
+
+  /** Parse a boolean literal in SMT context */
+  parseSmtBoolLit() {
+    const tok = this.advance();
+    return litNode('Bool', tok.value === 'true');
+  }
+
+  // ─── Infix Parser (Recursive Descent) ─────────────────────────────────
+
+  /**
+   * disj ::= conj ( ('or' | '||') conj )*
+   */
+  parseDisjunction() {
+    let left = this.parseConjunction();
+
+    while (this.check(TokenType.OR)) {
+      this.advance();
+      const right = this.parseConjunction();
+      left = binopNode('or', left, right);
+    }
+
+    return left;
+  }
+
+  /**
+   * conj ::= neg ( ('and' | '&&') neg )*
+   */
+  parseConjunction() {
+    let left = this.parseNegation();
+
+    while (this.check(TokenType.AND)) {
+      this.advance();
+      const right = this.parseNegation();
+      left = binopNode('and', left, right);
+    }
+
+    return left;
+  }
+
+  /**
+   * neg ::= ('not' neg) | cmp
+   */
+  parseNegation() {
+    if (this.check(TokenType.NOT)) {
+      const tok = this.advance();
+      const operand = this.parseNegation();
+      return unaryNode('not', operand);
+    }
+    return this.parseComparison();
+  }
+
+  /**
+   * cmp ::= arith ( rel_op arith )?
+   */
+  parseComparison() {
+    const left = this.parseArithmetic();
+
+    const tok = this.peek();
+    if (tok.type === TokenType.EQ ||
+        tok.type === TokenType.DISTINCT ||
+        tok.type === TokenType.LT ||
+        tok.type === TokenType.LE ||
+        tok.type === TokenType.GT ||
+        tok.type === TokenType.GE) {
+      const opTok = this.advance();
+      const right = this.parseArithmetic();
+      const op = opTok.type === TokenType.DISTINCT ? 'distinct' : opTok.value;
+      return binopNode(op, left, right);
+    }
+
+    return left;
+  }
+
+  /**
+   * arith ::= term ( ('+' | '-') term )*
+   */
+  parseArithmetic() {
+    let left = this.parseTerm();
+
+    while (this.check(TokenType.PLUS) || this.check(TokenType.MINUS)) {
+      const opTok = this.advance();
+      const right = this.parseTerm();
+      left = binopNode(opTok.value, left, right);
+    }
+
+    return left;
+  }
+
+  /**
+   * term ::= factor ( ('*' | '/') factor )*
+   */
+  parseTerm() {
+    let left = this.parseFactor();
+
+    while (this.check(TokenType.STAR) || this.check(TokenType.SLASH)) {
+      const opTok = this.advance();
+      const right = this.parseFactor();
+      left = binopNode(opTok.value, left, right);
+    }
+
+    return left;
+  }
+
+  /**
+   * factor ::= '(' infix_expr ')' | var_ref | number | bool_lit
+   */
+  parseFactor() {
+    const tok = this.peek();
+
+    // Parenthesized expression
+    if (tok.type === TokenType.LPAREN) {
+      this.advance(); // (
+      const inner = this.parseDisjunction();
+      this.expect(TokenType.RPAREN);
+      return inner;
+    }
+
+    // Number literals
+    if (tok.type === TokenType.INTEGER || tok.type === TokenType.REAL) {
+      this.advance();
+      if (tok.type === TokenType.REAL) {
+        return litNode('Real', parseFloat(tok.value));
+      }
+      return litNode('Int', parseInt(tok.value, 10));
+    }
+
+    // Boolean literals
+    if (tok.type === TokenType.BOOL_LIT) {
+      this.advance();
+      return litNode('Bool', tok.value === 'true');
+    }
+
+    // Identifier (possibly primed)
+    if (tok.type === TokenType.IDENT) {
+      this.advance();
+      if (this.check(TokenType.PRIME)) {
+        if (!this.isPostcondition) {
+          throw new ParseError(
+            `Primed variable '${tok.value}'' is not allowed in preconditions`,
+            tok.pos
+          );
+        }
+        this.advance(); // consume '
+        return varNode(tok.value, true);
+      }
+      return varNode(tok.value, false);
+    }
+
+    // Unary minus in factor position (e.g., -x, -5)
+    if (tok.type === TokenType.MINUS) {
+      this.advance();
+      const operand = this.parseFactor();
+      // Optimize: if operand is a literal number, negate it directly
+      if (operand.type === NodeType.LITERAL && (operand.sort === 'Int' || operand.sort === 'Real')) {
+        operand.value = -operand.value;
+        return operand;
+      }
+      return unaryNode('-', operand);
+    }
+
+    // Unary plus (discard)
+    if (tok.type === TokenType.PLUS) {
+      this.advance();
+      return this.parseFactor();
+    }
+
+    throw new ParseError(
+      `Unexpected token '${tok.value}' — expected variable, number, boolean, or '('`,
+      tok.pos
+    );
+  }
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────
+
+/**
+ * Parse a guard expression string into an AST.
+ *
+ * @param {string} input - The expression string
+ * @param {Object} [options]
+ * @param {boolean} [options.isPostcondition=false] - Whether primed variables are allowed
+ * @returns {{ ast: Object|null, tokens: import('./guard-lexer.js').Token[] }}
+ * @throws {ParseError|LexerError} On syntax or lexical errors
+ */
+export function parse(input, options = {}) {
+  const isPostcondition = options.isPostcondition || false;
+  const trimmed = (input || '').trim();
+
+  if (!trimmed) {
+    return { ast: null, tokens: [] };
+  }
+
+  const tokens = tokenize(trimmed);
+  const parser = new Parser(tokens, isPostcondition);
+  const ast = parser.parseExpression();
+
+  return { ast, tokens };
+}
+
+export { LexerError };

--- a/src/extensions/guard-language/guard-smt-emitter.js
+++ b/src/extensions/guard-language/guard-smt-emitter.js
@@ -1,0 +1,201 @@
+/**
+ * Guard Language SMT Emitter
+ * Converts guard expression ASTs to SMT-LIB2 prefix form with per-step variable indexing.
+ * Replaces the old _rewriteGuard / _infixToSmt / _applyStepVars methods in smt-generator.js.
+ */
+
+import { NodeType } from './guard-parser.js';
+
+/**
+ * Convert an AST to SMT-LIB2 prefix form with step-indexed variables.
+ *
+ * - Reads (unprimed idents): variable v → v_<step>
+ * - Writes (primed idents):  variable v' → v_<step+1>
+ * - All primes are removed in the output (Z3 doesn't allow apostrophes in identifiers).
+ *
+ * @param {Object|null} ast - Parsed AST node
+ * @param {number} step - Current step index
+ * @param {Array<[string, string]>} dataVarsList - Array of [varName, sort] pairs
+ * @param {boolean} isPost - Whether this is a postcondition (primed writes go to step+1)
+ * @param {Function} [symFn] - Optional symbol sanitizer function (default: identity)
+ * @returns {string} SMT-LIB2 expression string, or empty string if ast is null
+ */
+export function toSmtLib2(ast, step, dataVarsList, isPost, symFn) {
+  if (!ast) return '';
+
+  const sym = symFn || ((s) => s);
+  const varNames = new Set(dataVarsList.map(([name]) => name));
+
+  /**
+   * Get the stepped variable name for a data variable reference.
+   */
+  function steppedVar(name, primed) {
+    if (varNames.has(name)) {
+      const targetStep = primed ? step + 1 : step;
+      return `${sym(name)}_${targetStep}`;
+    }
+    // Not a known data variable — return as-is (e.g., bound quantifier vars)
+    return sym(name);
+  }
+
+  function emit(node) {
+    switch (node.type) {
+      case NodeType.LITERAL:
+        if (node.sort === 'Bool') return node.value ? 'true' : 'false';
+        if (node.sort === 'Real') {
+          // Ensure real literals have decimal point
+          const s = String(node.value);
+          return s.includes('.') ? s : s + '.0';
+        }
+        return String(node.value);
+
+      case NodeType.VAR:
+        return steppedVar(node.name, node.primed);
+
+      case NodeType.BINOP:
+        return `(${node.op} ${emit(node.left)} ${emit(node.right)})`;
+
+      case NodeType.UNARYOP:
+        if (node.op === '-') {
+          // SMT-LIB2 unary minus: (- x)
+          return `(- ${emit(node.operand)})`;
+        }
+        return `(${node.op} ${emit(node.operand)})`;
+
+      case NodeType.CALL:
+        return `(${node.op} ${node.args.map(emit).join(' ')})`;
+
+      case NodeType.QUANTIFIER: {
+        const bindings = node.bindings
+          .map(b => `(${sym(b.name)} ${b.sort})`)
+          .join(' ');
+        return `(${node.kind} (${bindings}) ${emit(node.body)})`;
+      }
+
+      case NodeType.LET_EXPR: {
+        const bindings = node.bindings
+          .map(b => `(${sym(b.name)} ${emit(b.expr)})`)
+          .join(' ');
+        return `(let (${bindings}) ${emit(node.body)})`;
+      }
+
+      default:
+        return 'true';
+    }
+  }
+
+  return emit(ast);
+}
+
+/**
+ * Convert an AST to stepped SMT-LIB2 for τ-guard construction.
+ * In τ-guards, primed variables are replaced with bound write-variables (v_w)
+ * instead of stepped variables.
+ *
+ * @param {Object|null} ast - Parsed postcondition AST
+ * @param {number} step - Current step index
+ * @param {Array<[string, string]>} dataVarsList - Array of [varName, sort] pairs
+ * @param {Function} [symFn] - Optional symbol sanitizer function
+ * @returns {string} SMT-LIB2 expression string
+ */
+export function toSmtLib2ForTau(ast, step, dataVarsList, symFn) {
+  if (!ast) return '';
+
+  const sym = symFn || ((s) => s);
+  const varNames = new Set(dataVarsList.map(([name]) => name));
+
+  function steppedVar(name, primed) {
+    if (primed && varNames.has(name)) {
+      return `${sym(name)}_w`; // bound write variable for existential quantifier
+    }
+    if (varNames.has(name)) {
+      return `${sym(name)}_${step}`;
+    }
+    return sym(name);
+  }
+
+  function emit(node) {
+    switch (node.type) {
+      case NodeType.LITERAL:
+        if (node.sort === 'Bool') return node.value ? 'true' : 'false';
+        if (node.sort === 'Real') {
+          const s = String(node.value);
+          return s.includes('.') ? s : s + '.0';
+        }
+        return String(node.value);
+
+      case NodeType.VAR:
+        return steppedVar(node.name, node.primed);
+
+      case NodeType.BINOP:
+        return `(${node.op} ${emit(node.left)} ${emit(node.right)})`;
+
+      case NodeType.UNARYOP:
+        if (node.op === '-') return `(- ${emit(node.operand)})`;
+        return `(${node.op} ${emit(node.operand)})`;
+
+      case NodeType.CALL:
+        return `(${node.op} ${node.args.map(emit).join(' ')})`;
+
+      case NodeType.QUANTIFIER: {
+        const bindings = node.bindings
+          .map(b => `(${sym(b.name)} ${b.sort})`)
+          .join(' ');
+        return `(${node.kind} (${bindings}) ${emit(node.body)})`;
+      }
+
+      case NodeType.LET_EXPR: {
+        const bindings = node.bindings
+          .map(b => `(${sym(b.name)} ${emit(b.expr)})`)
+          .join(' ');
+        return `(let (${bindings}) ${emit(node.body)})`;
+      }
+
+      default:
+        return 'true';
+    }
+  }
+
+  return emit(ast);
+}
+
+/**
+ * Extract the set of written (primed) variable names from an AST.
+ * This replaces the old regex-based _writtenVars method.
+ *
+ * @param {Object|null} ast - Parsed postcondition AST
+ * @returns {Set<string>} Variable names that appear primed
+ */
+export function extractWrittenVars(ast) {
+  const written = new Set();
+  if (!ast) return written;
+
+  function walk(node) {
+    if (!node) return;
+    switch (node.type) {
+      case NodeType.VAR:
+        if (node.primed) written.add(node.name);
+        break;
+      case NodeType.BINOP:
+        walk(node.left);
+        walk(node.right);
+        break;
+      case NodeType.UNARYOP:
+        walk(node.operand);
+        break;
+      case NodeType.CALL:
+        for (const arg of node.args) walk(arg);
+        break;
+      case NodeType.QUANTIFIER:
+        walk(node.body);
+        break;
+      case NodeType.LET_EXPR:
+        for (const b of node.bindings) walk(b.expr);
+        walk(node.body);
+        break;
+    }
+  }
+
+  walk(ast);
+  return written;
+}

--- a/src/extensions/guard-language/guard-validator.js
+++ b/src/extensions/guard-language/guard-validator.js
@@ -1,0 +1,192 @@
+/**
+ * Guard Language Validator
+ * Validates guard expressions against the well-formedness constraints (spec §5).
+ * Returns parse errors with exact token positions for the expression editor dialog.
+ */
+
+import { parse, ParseError, LexerError } from './guard-parser.js';
+import { NodeType } from './guard-parser.js';
+
+/**
+ * Validate a guard expression.
+ *
+ * @param {string} expression - The expression string to validate
+ * @param {string[]} variableNames - Array of declared data variable names
+ * @param {boolean} isPrecondition - Whether this is a precondition (primes forbidden)
+ * @returns {{ valid: boolean, error: string|null, pos: number|null, ast: Object|null }}
+ */
+export function validate(expression, variableNames = [], isPrecondition = true) {
+  const trimmed = (expression || '').trim();
+
+  // Empty expression is always valid
+  if (!trimmed) {
+    return { valid: true, error: null, pos: null, ast: null };
+  }
+
+  // Step 1: Parse
+  let ast, tokens;
+  try {
+    ({ ast, tokens } = parse(trimmed, { isPostcondition: !isPrecondition }));
+  } catch (e) {
+    if (e instanceof ParseError || e instanceof LexerError) {
+      return { valid: false, error: e.message, pos: e.pos, ast: null };
+    }
+    return { valid: false, error: `Parse error: ${e.message}`, pos: null, ast: null };
+  }
+
+  if (!ast) {
+    return { valid: true, error: null, pos: null, ast: null };
+  }
+
+  // Step 2: Check well-formedness
+  const varSet = new Set(variableNames);
+  const result = checkWellFormedness(ast, varSet, isPrecondition);
+  if (result) {
+    return { valid: false, error: result.error, pos: result.pos, ast: null };
+  }
+
+  return { valid: true, error: null, pos: null, ast };
+}
+
+/**
+ * Check well-formedness of an AST (spec §5).
+ *
+ * @param {Object} node - AST node
+ * @param {Set<string>} varSet - Set of declared variable names
+ * @param {boolean} isPrecondition
+ * @returns {{ error: string, pos: number|null }|null} Error object or null if valid
+ */
+function checkWellFormedness(node, varSet, isPrecondition) {
+  if (!node) return null;
+
+  switch (node.type) {
+    case NodeType.LITERAL:
+      return null;
+
+    case NodeType.VAR: {
+      // Check that variable is declared
+      if (!varSet.has(node.name)) {
+        return {
+          error: `Unknown variable '${node.name}'. Declared variables: ${[...varSet].join(', ') || '(none)'}`,
+          pos: null
+        };
+      }
+      // Check priming rules
+      if (node.primed && isPrecondition) {
+        return {
+          error: `Primed variable '${node.name}'' is not allowed in preconditions`,
+          pos: null
+        };
+      }
+      return null;
+    }
+
+    case NodeType.BINOP: {
+      const lErr = checkWellFormedness(node.left, varSet, isPrecondition);
+      if (lErr) return lErr;
+      return checkWellFormedness(node.right, varSet, isPrecondition);
+    }
+
+    case NodeType.UNARYOP:
+      return checkWellFormedness(node.operand, varSet, isPrecondition);
+
+    case NodeType.CALL: {
+      for (const arg of node.args) {
+        const err = checkWellFormedness(arg, varSet, isPrecondition);
+        if (err) return err;
+      }
+      return null;
+    }
+
+    case NodeType.QUANTIFIER: {
+      // Extend variable set with bound names for body check
+      const extendedVars = new Set(varSet);
+      for (const binding of node.bindings) {
+        extendedVars.add(binding.name);
+      }
+      return checkWellFormedness(node.body, extendedVars, isPrecondition);
+    }
+
+    case NodeType.LET_EXPR: {
+      // Check binding expressions first
+      for (const binding of node.bindings) {
+        const err = checkWellFormedness(binding.expr, varSet, isPrecondition);
+        if (err) return err;
+      }
+      // Extend variable set with let bindings for body check
+      const extendedVars = new Set(varSet);
+      for (const binding of node.bindings) {
+        extendedVars.add(binding.name);
+      }
+      return checkWellFormedness(node.body, extendedVars, isPrecondition);
+    }
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * Validate a precondition expression (convenience wrapper).
+ *
+ * @param {string} expression
+ * @param {string[]} variableNames
+ * @returns {{ valid: boolean, error: string|null, pos: number|null }}
+ */
+export function validatePrecondition(expression, variableNames = []) {
+  const result = validate(expression, variableNames, true);
+  return { valid: result.valid, error: result.error, pos: result.pos };
+}
+
+/**
+ * Validate a postcondition expression (convenience wrapper).
+ * Additional checks: at least one primed variable should appear if the expression is non-empty.
+ *
+ * @param {string} expression
+ * @param {string[]} variableNames
+ * @returns {{ valid: boolean, error: string|null, pos: number|null }}
+ */
+export function validatePostcondition(expression, variableNames = []) {
+  const result = validate(expression, variableNames, false);
+  if (!result.valid) {
+    return { valid: false, error: result.error, pos: result.pos };
+  }
+
+  // If non-empty, check that at least one primed variable appears
+  if (result.ast) {
+    const hasPrimed = containsPrimedVar(result.ast);
+    if (!hasPrimed) {
+      return {
+        valid: false,
+        error: `Postcondition must contain at least one primed variable (e.g., x' = ...). ` +
+               `Use variable' to denote the next-state value.`,
+        pos: null
+      };
+    }
+  }
+
+  return { valid: true, error: null, pos: null };
+}
+
+/**
+ * Check if an AST contains any primed variable reference.
+ */
+function containsPrimedVar(node) {
+  if (!node) return false;
+  switch (node.type) {
+    case NodeType.VAR:
+      return node.primed;
+    case NodeType.BINOP:
+      return containsPrimedVar(node.left) || containsPrimedVar(node.right);
+    case NodeType.UNARYOP:
+      return containsPrimedVar(node.operand);
+    case NodeType.CALL:
+      return node.args.some(containsPrimedVar);
+    case NodeType.QUANTIFIER:
+      return containsPrimedVar(node.body);
+    case NodeType.LET_EXPR:
+      return node.bindings.some(b => containsPrimedVar(b.expr)) || containsPrimedVar(node.body);
+    default:
+      return false;
+  }
+}

--- a/src/extensions/pnml-importer.js
+++ b/src/extensions/pnml-importer.js
@@ -2,6 +2,7 @@ import { PetriNetAPI, Place, Transition, Arc } from '../petri-net-simulator.js';
 import { DataPetriNetAPI } from './dpn-api.js';
 import { DataAwareTransition, DataVariable } from './dpn-model.js';
 import { DataPetriNetRenderer } from './dpn-renderer.js';
+import { migratePrecondition, migratePostcondition } from './guard-language/guard-migrator.js';
 
 /**
  * PNML Importer Extension with Improved BPMN Layout Algorithm
@@ -697,8 +698,8 @@ class PNMLImporter {
             position: this.getPosition(transition),
             priority: 1,
             delay: 0,
-            precondition: precondition.replace(/'/g, ""),
-            postcondition: postcondition,
+            precondition: migratePrecondition(precondition.replace(/'/g, "")),
+            postcondition: migratePostcondition(postcondition),
             isDataAware: isDataAware,
             silent: isSilent
           };

--- a/src/extensions/python-dpn-transpiler.js
+++ b/src/extensions/python-dpn-transpiler.js
@@ -1,0 +1,841 @@
+import { DataPetriNet, DataAwareTransition, DataVariable } from './dpn-model.js';
+import { Place, Transition, Arc } from '../petri-net-simulator.js';
+
+
+/**
+ * Translate Python source code into a YAPNE-compatible Data Petri Net.
+ *
+ * The translation preserves recall of 1: every feasible execution trace of
+ * the input Python program corresponds to a firing sequence of the produced
+ * DPN. At generalization 0 precision is also 1, i.e. every firing sequence
+ * of the DPN matches some Python trace. Raising generalization progressively
+ * drops postconditions (variable effects) and then preconditions (branch
+ * guards), trading precision for simplicity while preserving recall.
+ *
+ * Guards and postconditions are emitted in JavaScript-compatible infix form
+ * (`&&`, `||`, `!`, `==`, `!=`, `<`, `<=`, `>`, `>=`, arithmetic, primes)
+ * so that the net simulates correctly under YAPNE's runtime evaluator, which
+ * compiles each expression via `new Function(...)`.
+ *
+ * Branch guards are merged into the first real transition of each branch
+ * whenever possible. A silent gate transition is emitted only when a branch
+ * body is empty or begins with a loop whose header would otherwise re-apply
+ * the guard on every iteration.
+ */
+class PythonToDPN {
+  /**
+   * Create a new translator.
+   *
+   * @param {{generalization?: number, depth?: number, name?: string}} [options]
+   *   - generalization: number in [0, 1] controlling how aggressively guards
+     and effects are dropped. Values >= 0.4 drop postconditions; values
+     >= 0.8 additionally drop preconditions. Default 0 (exact translation).
+   *   - depth: maximum function-call inlining depth. 0 keeps every call as a
+     single opaque transition; n > 0 inlines up to n nested call levels.
+     Default 1.
+   *   - name: display name for the produced DataPetriNet. Default 'Python Program'.
+   */
+  constructor(options = {}) {
+    this.generalization = options.generalization ?? 0;
+    this.depth = options.depth ?? 1;
+    this.name = options.name ?? 'Python Program';
+  }
+
+  /**
+   * Convert a Python source string into a Data Petri Net.
+   *
+   * @param {string} code - Raw Python source code.
+   * @returns {DataPetriNet} A populated DataPetriNet instance. Call `.toJSON()`
+   *   on the result to persist it or import it into YAPNE.
+   */
+  convert(code) {
+    this._dpn = new DataPetriNet(this._uuid(), this.name, 'Generated from Python source');
+    this._variables = new Map();
+    this._functions = new Map();
+    this._loopStack = [];
+    this._callDepth = 0;
+    this._gridX = 0;
+    this._gridY = 0;
+
+    const topLevel = [];
+    for (const stmt of this._parseProgram(code)) {
+      if (stmt.kind === 'def') {
+        this._functions.set(stmt.name, stmt);
+      } else {
+        topLevel.push(stmt);
+      }
+    }
+
+    const start = this._addPlace('start', 1);
+    const exit = this._buildBlock(topLevel, start);
+    if (exit !== null) {
+      this._dpn.getPlace(exit).finalMarking = 1;
+    }
+
+    for (const [name, type] of this._variables) {
+      this._dpn.addDataVariable(
+        new DataVariable(this._uuid(), name, type, this._defaultValue(type))
+      );
+    }
+    return this._dpn;
+  }
+
+  /**
+   * Parse a full Python program into a list of top-level statement ASTs.
+   *
+   * @param {string} code - Raw Python source.
+   * @returns {Array<Object>} Parsed statement nodes.
+   */
+  _parseProgram(code) {
+    const lines = [];
+    for (const raw of code.split('\n')) {
+      const stripped = this._stripComment(raw);
+      if (stripped.trim() === '') continue;
+      const indent = stripped.length - stripped.trimStart().length;
+      lines.push({ indent: indent, text: stripped.trim() });
+    }
+    return this._parseBlock(lines, 0, 0).stmts;
+  }
+
+  /**
+   * Remove a trailing line comment from a Python source line, ignoring `#`
+   * characters that occur inside string literals.
+   *
+   * @param {string} line - A single line of Python source.
+   * @returns {string} The line without its trailing comment.
+   */
+  _stripComment(line) {
+    let inStr = null;
+    for (let i = 0; i < line.length; i++) {
+      const c = line[i];
+      if (inStr) {
+        if (c === inStr && line[i - 1] !== '\\') inStr = null;
+      } else if (c === '"' || c === "'") {
+        inStr = c;
+      } else if (c === '#') {
+        return line.substring(0, i);
+      }
+    }
+    return line;
+  }
+
+  /**
+   * Parse a contiguous block of statements at indentation >= `indent`.
+   *
+   * @param {Array<{indent: number, text: string}>} lines - Pre-tokenized lines.
+   * @param {number} start - Starting line index.
+   * @param {number} indent - Required minimum indentation for the block.
+   * @returns {{stmts: Array<Object>, nextIdx: number}} Parsed statements and
+   *   the index of the first line not belonging to the block.
+   */
+  _parseBlock(lines, start, indent) {
+    const stmts = [];
+    let i = start;
+    while (i < lines.length && lines[i].indent >= indent) {
+      if (lines[i].indent > indent) {
+        i++;
+        continue;
+      }
+      const { stmt, nextIdx } = this._parseStatement(lines, i);
+      if (stmt) stmts.push(stmt);
+      i = nextIdx;
+    }
+    return { stmts: stmts, nextIdx: i };
+  }
+
+  /**
+   * Parse a single statement starting at line index `idx`.
+   *
+   * @param {Array<{indent: number, text: string}>} lines - Pre-tokenized lines.
+   * @param {number} idx - Line index of the statement's first line.
+   * @returns {{stmt: Object|null, nextIdx: number}} Parsed AST node (or null
+   *   for an unrecognized line) and the index of the next unparsed line.
+   */
+  _parseStatement(lines, idx) {
+    const text = lines[idx].text;
+
+    if (text.startsWith('if ') && text.endsWith(':')) {
+      return this._parseIfChain(lines, idx);
+    }
+    if (text.startsWith('while ') && text.endsWith(':')) {
+      const cond = text.slice(6, -1).trim();
+      const child = this._childIndent(lines, idx);
+      const body = this._parseBlock(lines, idx + 1, child);
+      return { stmt: { kind: 'while', cond: cond, body: body.stmts }, nextIdx: body.nextIdx };
+    }
+    if (text.startsWith('for ')) {
+      const m = text.match(/^for\s+([A-Za-z_]\w*)\s+in\s+(.+):$/);
+      if (m) {
+        const child = this._childIndent(lines, idx);
+        const body = this._parseBlock(lines, idx + 1, child);
+        return {
+          stmt: { kind: 'for', variable: m[1], iterable: m[2].trim(), body: body.stmts },
+          nextIdx: body.nextIdx
+        };
+      }
+    }
+    if (text.startsWith('def ')) {
+      const m = text.match(/^def\s+([A-Za-z_]\w*)\s*\(([^)]*)\)\s*:$/);
+      if (m) {
+        const child = this._childIndent(lines, idx);
+        const body = this._parseBlock(lines, idx + 1, child);
+        const params = m[2].split(',').map(p => p.trim()).filter(p => p.length > 0);
+        return {
+          stmt: { kind: 'def', name: m[1], params: params, body: body.stmts },
+          nextIdx: body.nextIdx
+        };
+      }
+    }
+    if (text === 'return' || text.startsWith('return ')) {
+      const expr = text === 'return' ? null : text.slice(7).trim();
+      return { stmt: { kind: 'return', expr: expr }, nextIdx: idx + 1 };
+    }
+    if (text === 'pass')     return { stmt: { kind: 'pass' },     nextIdx: idx + 1 };
+    if (text === 'break')    return { stmt: { kind: 'break' },    nextIdx: idx + 1 };
+    if (text === 'continue') return { stmt: { kind: 'continue' }, nextIdx: idx + 1 };
+
+    const aug = text.match(/^([A-Za-z_]\w*)\s*(\+=|-=|\*=|\/=)\s*(.+)$/);
+    if (aug) {
+      return {
+        stmt: { kind: 'assign', variable: aug[1], op: aug[2], expr: aug[3].trim() },
+        nextIdx: idx + 1
+      };
+    }
+
+    const assign = text.match(/^([A-Za-z_]\w*)\s*=(?!=)\s*(.+)$/);
+    if (assign) {
+      return {
+        stmt: { kind: 'assign', variable: assign[1], op: '=', expr: assign[2].trim() },
+        nextIdx: idx + 1
+      };
+    }
+
+    const call = this._matchPureCall(text);
+    if (call) {
+      return { stmt: { kind: 'call', name: call.name, args: call.args }, nextIdx: idx + 1 };
+    }
+
+    return { stmt: { kind: 'expr', text: text }, nextIdx: idx + 1 };
+  }
+
+  /**
+   * Parse an if/elif+/else chain into a right-nested if AST.
+   *
+   * @param {Array<{indent: number, text: string}>} lines - Pre-tokenized lines.
+   * @param {number} idx - Line index of the `if` header.
+   * @returns {{stmt: Object, nextIdx: number}} The nested if AST and the next index.
+   */
+  _parseIfChain(lines, idx) {
+    const own = lines[idx].indent;
+    const branches = [];
+
+    const firstCond = lines[idx].text.slice(3, -1).trim();
+    const firstChild = this._childIndent(lines, idx);
+    const firstBody = this._parseBlock(lines, idx + 1, firstChild);
+    branches.push({ cond: firstCond, body: firstBody.stmts });
+    let i = firstBody.nextIdx;
+
+    while (i < lines.length && lines[i].indent === own) {
+      const t = lines[i].text;
+      if (t.startsWith('elif ') && t.endsWith(':')) {
+        const c = t.slice(5, -1).trim();
+        const ci = this._childIndent(lines, i);
+        const b = this._parseBlock(lines, i + 1, ci);
+        branches.push({ cond: c, body: b.stmts });
+        i = b.nextIdx;
+      } else if (t === 'else:') {
+        const ci = this._childIndent(lines, i);
+        const b = this._parseBlock(lines, i + 1, ci);
+        branches.push({ cond: null, body: b.stmts });
+        i = b.nextIdx;
+        break;
+      } else {
+        break;
+      }
+    }
+
+    let elseBody = [];
+    if (branches[branches.length - 1].cond === null) {
+      elseBody = branches.pop().body;
+    }
+    let result = elseBody;
+    for (let k = branches.length - 1; k >= 0; k--) {
+      result = [{
+        kind: 'if',
+        cond: branches[k].cond,
+        thenBody: branches[k].body,
+        elseBody: result
+      }];
+    }
+    return { stmt: result[0], nextIdx: i };
+  }
+
+  /**
+   * Determine the indentation level of the block following a header line.
+   *
+   * @param {Array<{indent: number, text: string}>} lines - Pre-tokenized lines.
+   * @param {number} idx - Index of the header line (e.g. an `if x:` line).
+   * @returns {number} Indentation of the child block, or the header's indent + 4
+   *   when the child block is empty.
+   */
+  _childIndent(lines, idx) {
+    if (idx + 1 < lines.length && lines[idx + 1].indent > lines[idx].indent) {
+      return lines[idx + 1].indent;
+    }
+    return lines[idx].indent + 4;
+  }
+
+  /**
+   * Match a statement that is exactly a single function call with balanced parentheses.
+   *
+   * @param {string} text - The trimmed statement line.
+   * @returns {{name: string, args: string}|null} Name and raw argument string,
+   *   or null if the line is not a pure call.
+   */
+  _matchPureCall(text) {
+    const head = text.match(/^([A-Za-z_]\w*)\s*\(/);
+    if (!head) return null;
+    let depth = 1;
+    let i = head[0].length;
+    while (i < text.length && depth > 0) {
+      const c = text[i];
+      if (c === '(') depth++;
+      else if (c === ')') depth--;
+      i++;
+    }
+    if (depth !== 0 || i !== text.length) return null;
+    return { name: head[1], args: text.substring(head[0].length, i - 1) };
+  }
+
+  /**
+   * Build the DPN sub-graph for a sequence of statements.
+   *
+   * @param {Array<Object>} stmts - Statement AST nodes.
+   * @param {string} entry - Id of the place where control enters the block.
+   * @param {string|null} [pendingGuard] - Guard that must hold on the first
+   *   real transition emitted by this block. Absorbed into the precondition
+   *   of the first builder that can carry it; if the block is empty it is
+   *   emitted as a silent gate transition.
+   * @param {string|null} [targetExit] - If provided, the last transition of
+   *   this block outputs directly to this place instead of a fresh one; used
+   *   to collapse branch-merge places.
+   * @returns {string|null} Id of the exit place, or null when control does
+   *   not fall through (after a return, break, or continue).
+   */
+  _buildBlock(stmts, entry, pendingGuard = null, targetExit = null) {
+    if (stmts.length === 0) {
+      if (pendingGuard === null && targetExit === null) return entry;
+      const next = targetExit || this._addPlace('');
+      const t = this._addTransition('', this._generalizePre(pendingGuard), null, true);
+      this._addArc(entry, t);
+      this._addArc(t, next);
+      return next;
+    }
+    let cur = entry;
+    let pending = pendingGuard;
+    for (let i = 0; i < stmts.length; i++) {
+      if (cur === null) break;
+      const last = i === stmts.length - 1;
+      cur = this._buildStmt(stmts[i], cur, pending, last ? targetExit : null);
+      pending = null;
+    }
+    return cur;
+  }
+
+  /**
+   * Dispatch to the builder for a single statement.
+   *
+   * @param {Object} stmt - Statement AST node.
+   * @param {string} entry - Entry place id.
+   * @param {string|null} pendingGuard - Guard to attach to the first real transition.
+   * @param {string|null} targetExit - If set, the statement's last transition
+   *   outputs directly to this place.
+   * @returns {string|null} Exit place id, or null for non-falling-through statements.
+   */
+  _buildStmt(stmt, entry, pendingGuard = null, targetExit = null) {
+    switch (stmt.kind) {
+      case 'assign':   return this._buildAssign(stmt, entry, pendingGuard, targetExit);
+      case 'if':       return this._buildIf(stmt, entry, pendingGuard, targetExit);
+      case 'while':    return this._buildWhile(stmt, entry, pendingGuard, targetExit);
+      case 'for':      return this._buildFor(stmt, entry, pendingGuard, targetExit);
+      case 'call':     return this._buildCall(stmt, entry, pendingGuard, targetExit);
+      case 'return':   return this._buildReturn(stmt, entry, pendingGuard);
+      case 'pass':     return this._buildPass(entry, pendingGuard, targetExit);
+      case 'break':    return this._buildJump(entry, 'break', pendingGuard);
+      case 'continue': return this._buildJump(entry, 'continue', pendingGuard);
+      case 'expr':     return this._buildOpaque(stmt.text, entry, pendingGuard, targetExit);
+      default:         return entry;
+    }
+  }
+
+  /**
+   * Emit a transition encoding a Python assignment `x = rhs` or augmented form.
+   *
+   * @param {{variable: string, op: string, expr: string}} stmt - Assignment AST.
+   * @param {string} entry - Entry place id.
+   * @param {string|null} pendingGuard - Guard merged into the transition's precondition.
+   * @param {string|null} targetExit - Optional target output place.
+   * @returns {string} Exit place id.
+   */
+  _buildAssign(stmt, entry, pendingGuard = null, targetExit = null) {
+    this._ensureVariable(stmt.variable, this._inferType(stmt.expr));
+    const rhs = this._translateExpr(stmt.expr);
+    let post = null;
+    if (this._isSupported(rhs)) {
+      const body = stmt.op === '='
+        ? rhs
+        : `${stmt.variable} ${stmt.op[0]} (${rhs})`;
+      post = `${stmt.variable}' = ${body}`;
+    }
+    const label = `${stmt.variable} ${stmt.op} ${stmt.expr}`;
+    const next = targetExit || this._addPlace('');
+    const pre = this._generalizePre(pendingGuard);
+    const t = this._addTransition(label, pre, this._generalizePost(post), false);
+    this._addArc(entry, t);
+    this._addArc(t, next);
+    return next;
+  }
+
+  /**
+   * Emit the branching structure for a Python if/else statement. The branch
+   * guard is pushed into each branch as a pending guard so that it merges
+   * with the first real transition of the branch instead of producing a
+   * dedicated silent guard transition.
+   *
+   * @param {{cond: string, thenBody: Array<Object>, elseBody: Array<Object>}} stmt - If AST.
+   * @param {string} entry - Entry place id.
+   * @param {string|null} pendingGuard - Outer guard to combine with each branch guard.
+   * @param {string|null} targetExit - Optional merge place supplied by the caller.
+   * @returns {string} Id of the place where both branches rejoin.
+   */
+  _buildIf(stmt, entry, pendingGuard = null, targetExit = null) {
+    const cond = this._translateExpr(stmt.cond);
+    const pre = this._isSupported(cond) ? cond : null;
+    const negPre = pre === null ? null : `!(${pre})`;
+    const merge = targetExit || this._addPlace('');
+
+    this._buildBlock(stmt.thenBody, entry, this._combineGuards(pendingGuard, pre), merge);
+    this._buildBlock(stmt.elseBody, entry, this._combineGuards(pendingGuard, negPre), merge);
+
+    return merge;
+  }
+
+  /**
+   * Emit a loop structure for a Python while statement. Because the loop
+   * header is revisited on each iteration, a pending guard cannot be merged
+   * into the header's enter/exit transitions without changing semantics, so
+   * it is consumed by a dedicated silent gate transition immediately before
+   * the header.
+   *
+   * @param {{cond: string, body: Array<Object>}} stmt - While AST.
+   * @param {string} entry - Entry place id.
+   * @param {string|null} pendingGuard - Guard consumed by a silent gate before the header.
+   * @param {string|null} targetExit - Optional exit place to reuse.
+   * @returns {string} Id of the loop's exit place.
+   */
+  _buildWhile(stmt, entry, pendingGuard = null, targetExit = null) {
+    let header = entry;
+    if (pendingGuard !== null) {
+      const gated = this._addPlace('');
+      const tGate = this._addTransition('', this._generalizePre(pendingGuard), null, true);
+      this._addArc(entry, tGate);
+      this._addArc(tGate, gated);
+      header = gated;
+    }
+
+    const cond = this._translateExpr(stmt.cond);
+    const pre = this._isSupported(cond) ? cond : null;
+    const negPre = pre === null ? null : `!(${pre})`;
+
+    const bodyEntry = this._addPlace('');
+    const exitPlace = targetExit || this._addPlace('');
+
+    const tEnter = this._addTransition('[while-enter]', this._generalizePre(pre), null, true);
+    this._addArc(header, tEnter);
+    this._addArc(tEnter, bodyEntry);
+
+    const tExit = this._addTransition('[while-exit]', this._generalizePre(negPre), null, true);
+    this._addArc(header, tExit);
+    this._addArc(tExit, exitPlace);
+
+    this._loopStack.push({ back: header, exit: exitPlace });
+    const bodyExit = this._buildBlock(stmt.body, bodyEntry);
+    this._loopStack.pop();
+
+    if (bodyExit !== null) {
+      const tBack = this._addTransition('', null, null, true);
+      this._addArc(bodyExit, tBack);
+      this._addArc(tBack, header);
+    }
+    return exitPlace;
+  }
+
+  /**
+   * Emit a loop for `for v in range(...)`. Other iterables collapse to an
+   * opaque transition.
+   *
+   * @param {{variable: string, iterable: string, body: Array<Object>}} stmt - For AST.
+   * @param {string} entry - Entry place id.
+   * @param {string|null} pendingGuard - Guard merged into the initializer assignment.
+   * @param {string|null} targetExit - Optional exit place.
+   * @returns {string} Exit place id after the loop.
+   */
+  _buildFor(stmt, entry, pendingGuard = null, targetExit = null) {
+    const m = stmt.iterable.match(
+      /^range\s*\(\s*([^,)]+)(?:\s*,\s*([^,)]+))?(?:\s*,\s*([^)]+))?\s*\)$/
+    );
+    if (m) {
+      const startExpr = m[2] ? m[1].trim() : '0';
+      const endExpr = m[2] ? m[2].trim() : m[1].trim();
+      const stepExpr = m[3] ? m[3].trim() : '1';
+      this._ensureVariable(stmt.variable, 'int');
+      const init = { kind: 'assign', variable: stmt.variable, op: '=', expr: startExpr };
+      const inc = {
+        kind: 'assign',
+        variable: stmt.variable,
+        op: '=',
+        expr: `${stmt.variable} + ${stepExpr}`
+      };
+      const whileStmt = {
+        kind: 'while',
+        cond: `${stmt.variable} < ${endExpr}`,
+        body: stmt.body.concat([inc])
+      };
+      const afterInit = this._buildAssign(init, entry, pendingGuard, null);
+      return this._buildWhile(whileStmt, afterInit, null, targetExit);
+    }
+    return this._buildOpaque(
+      `for ${stmt.variable} in ${stmt.iterable}`,
+      entry,
+      pendingGuard,
+      targetExit
+    );
+  }
+
+  /**
+   * Emit a function call, either inlining the body (when the function is
+   * known and current depth permits) or as a single opaque transition.
+   *
+   * @param {{name: string, args: string}} stmt - Call AST.
+   * @param {string} entry - Entry place id.
+   * @param {string|null} pendingGuard - Guard merged into the call's first transition.
+   * @param {string|null} targetExit - Optional exit place to reuse.
+   * @returns {string} Exit place id after the call.
+   */
+  _buildCall(stmt, entry, pendingGuard = null, targetExit = null) {
+    const fn = this._functions.get(stmt.name);
+    if (fn && this._callDepth < this.depth) {
+      let cur = entry;
+      let pending = pendingGuard;
+      if (fn.params.length > 0) {
+        const args = this._splitArgs(stmt.args);
+        const clauses = [];
+        for (let i = 0; i < Math.min(fn.params.length, args.length); i++) {
+          const p = fn.params[i];
+          const a = args[i];
+          this._ensureVariable(p, this._inferType(a));
+          const rhs = this._translateExpr(a);
+          if (this._isSupported(rhs)) clauses.push(`${p}' = ${rhs}`);
+        }
+        if (clauses.length > 0) {
+          const next = this._addPlace('');
+          const bind = this._addTransition(
+            `[call ${stmt.name}]`,
+            this._generalizePre(pending),
+            this._generalizePost(clauses.join('; ')),
+            true
+          );
+          this._addArc(cur, bind);
+          this._addArc(bind, next);
+          cur = next;
+          pending = null;
+        }
+      }
+      this._callDepth++;
+      const exit = this._buildBlock(fn.body, cur, pending, targetExit);
+      this._callDepth--;
+      return exit === null ? (targetExit || this._addPlace('')) : exit;
+    }
+    return this._buildOpaque(
+      `${stmt.name}(${stmt.args})`,
+      entry,
+      pendingGuard,
+      targetExit
+    );
+  }
+
+  /**
+   * Emit a single unguarded transition with the given label for statements
+   * whose semantics are not modeled, optionally merging a pending guard.
+   *
+   * @param {string} label - Label for the transition.
+   * @param {string} entry - Entry place id.
+   * @param {string|null} pendingGuard - Guard merged into the transition's precondition.
+   * @param {string|null} targetExit - Optional exit place to reuse.
+   * @returns {string} Exit place id.
+   */
+  _buildOpaque(label, entry, pendingGuard = null, targetExit = null) {
+    const next = targetExit || this._addPlace('');
+    const t = this._addTransition(label, this._generalizePre(pendingGuard), null, false);
+    this._addArc(entry, t);
+    this._addArc(t, next);
+    return next;
+  }
+
+  /**
+   * Emit a return statement as a labeled transition terminating in a final place.
+   *
+   * @param {{expr: string|null}} stmt - Return AST.
+   * @param {string} entry - Entry place id.
+   * @param {string|null} pendingGuard - Guard merged into the return transition.
+   * @returns {null} Always null; no fall-through.
+   */
+  _buildReturn(stmt, entry, pendingGuard = null) {
+    const final = this._addPlace('end', 0);
+    this._dpn.getPlace(final).finalMarking = 1;
+    const t = this._addTransition('return', this._generalizePre(pendingGuard), null, false);
+    this._addArc(entry, t);
+    this._addArc(t, final);
+    return null;
+  }
+
+  /**
+   * Emit a silent edge to the enclosing loop's exit or back place.
+   *
+   * @param {string} entry - Entry place id.
+   * @param {'break'|'continue'} kind - Jump kind.
+   * @param {string|null} pendingGuard - Guard merged into the jump transition.
+   * @returns {null} Always null; no fall-through.
+   */
+  _buildJump(entry, kind, pendingGuard = null) {
+    const loop = this._loopStack[this._loopStack.length - 1];
+    if (!loop) return entry;
+    const target = kind === 'break' ? loop.exit : loop.back;
+    const t = this._addTransition(`[${kind}]`, this._generalizePre(pendingGuard), null, true);
+    this._addArc(entry, t);
+    this._addArc(t, target);
+    return null;
+  }
+
+  /**
+   * Handle a `pass` statement. When neither a pending guard nor a target exit
+   * is supplied, pass-through requires no transition; otherwise a silent
+   * transition is emitted to carry the guard or bridge to the target.
+   *
+   * @param {string} entry - Entry place id.
+   * @param {string|null} pendingGuard - Guard to discharge.
+   * @param {string|null} targetExit - Optional exit place to reach.
+   * @returns {string} Exit place id.
+   */
+  _buildPass(entry, pendingGuard = null, targetExit = null) {
+    if (pendingGuard === null && targetExit === null) return entry;
+    const next = targetExit || this._addPlace('');
+    const t = this._addTransition('', this._generalizePre(pendingGuard), null, true);
+    this._addArc(entry, t);
+    this._addArc(t, next);
+    return next;
+  }
+
+  /**
+   * Conjoin two guards. Each operand is parenthesized so that the result is
+   * safe under all operator precedences.
+   *
+   * @param {string|null} a - First guard or null.
+   * @param {string|null} b - Second guard or null.
+   * @returns {string|null} The conjunction, the non-null operand, or null.
+   */
+  _combineGuards(a, b) {
+    if (!a) return b || null;
+    if (!b) return a || null;
+    return `(${a}) && (${b})`;
+  }
+
+  /**
+   * Split a call's argument string on top-level commas, honoring nested
+   * parentheses and brackets.
+   *
+   * @param {string} args - Raw content between the call's parentheses.
+   * @returns {Array<string>} Trimmed argument expressions.
+   */
+  _splitArgs(args) {
+    const out = [];
+    let depth = 0;
+    let current = '';
+    for (const c of args) {
+      if (c === '(' || c === '[' || c === '{') depth++;
+      else if (c === ')' || c === ']' || c === '}') depth--;
+      if (c === ',' && depth === 0) {
+        if (current.trim()) out.push(current.trim());
+        current = '';
+      } else {
+        current += c;
+      }
+    }
+    if (current.trim()) out.push(current.trim());
+    return out;
+  }
+
+  /**
+   * Translate a Python expression into the JavaScript-compatible infix form
+   * expected by YAPNE's runtime precondition and postcondition evaluator.
+   *
+   * @param {string} expr - Python expression as source text.
+   * @returns {string} Translated expression.
+   */
+  _translateExpr(expr) {
+    let e = expr;
+    e = e.replace(/\bTrue\b/g, 'true');
+    e = e.replace(/\bFalse\b/g, 'false');
+    e = e.replace(/\bNone\b/g, 'null');
+    e = e.replace(/\/\//g, '/');
+    e = e.replace(/\bnot\b/g, '!');
+    e = e.replace(/\band\b/g, '&&');
+    e = e.replace(/\bor\b/g, '||');
+    return e;
+  }
+
+  /**
+   * Test whether a translated expression uses only constructs the runtime
+   * evaluator can execute over the supported variable types.
+   *
+   * @param {string} expr - Translated expression.
+   * @returns {boolean} True if the expression is safe to emit as-is.
+   */
+  _isSupported(expr) {
+    if (!expr) return false;
+    if (/\b(in|is)\b/.test(expr)) return false;
+    if (/[\[\]\{\}]/.test(expr)) return false;
+    return true;
+  }
+
+  /**
+   * Guess the type of a Python right-hand side expression. First-write type
+   * wins and is kept for the lifetime of the variable.
+   *
+   * @param {string} expr - Right-hand side source text.
+   * @returns {string} One of 'int', 'float', 'boolean', 'string'.
+   */
+  _inferType(expr) {
+    if (!expr) return 'int';
+    const t = expr.trim();
+    if (/^(True|False|true|false)$/.test(t)) return 'boolean';
+    if (/^['"].*['"]$/.test(t)) return 'string';
+    if (/^[+-]?\d+\.\d+/.test(t)) return 'float';
+    if (/\b(and|or|not)\b|[<>!]=|==|[<>]/.test(t)) return 'boolean';
+    return 'int';
+  }
+
+  /**
+   * Return the default initial value for a given DataVariable type.
+   *
+   * @param {string} type - One of 'int', 'float', 'boolean', 'string'.
+   * @returns {number|boolean|string} The default initial value.
+   */
+  _defaultValue(type) {
+    switch (type) {
+      case 'float':   return 0.0;
+      case 'boolean': return false;
+      case 'string':  return '';
+      default:        return 0;
+    }
+  }
+
+  /**
+   * Register a data variable, keeping the first-seen type.
+   *
+   * @param {string} name - Variable name.
+   * @param {string} type - Inferred variable type.
+   * @returns {void}
+   */
+  _ensureVariable(name, type) {
+    if (!this._variables.has(name)) this._variables.set(name, type);
+  }
+
+  /**
+   * Apply generalization to a precondition. Returns null (no guard) once
+   * generalization crosses the precondition-drop threshold.
+   *
+   * @param {string|null} guard - The raw guard expression or null.
+   * @returns {string|null} The kept guard or null.
+   */
+  _generalizePre(guard) {
+    if (!guard) return null;
+    return this.generalization >= 0.8 ? null : guard;
+  }
+
+  /**
+   * Apply generalization to a postcondition. Returns null (no effect) once
+   * generalization crosses the postcondition-drop threshold.
+   *
+   * @param {string|null} post - The raw postcondition expression or null.
+   * @returns {string|null} The kept postcondition or null.
+   */
+  _generalizePost(post) {
+    if (!post) return null;
+    return this.generalization >= 0.4 ? null : post;
+  }
+
+  /**
+   * Add a Place to the DPN at an auto-advanced grid position.
+   *
+   * @param {string} label - Label for the place.
+   * @param {number} [tokens=0] - Initial token count.
+   * @returns {string} Id of the new place.
+   */
+  _addPlace(label, tokens = 0) {
+    const id = this._uuid();
+    this._gridX += 80;
+    this._dpn.addPlace(new Place(id, { x: this._gridX, y: this._gridY }, label, tokens));
+    return id;
+  }
+
+  /**
+   * Add a Transition to the DPN. A DataAwareTransition is used when either
+   * a precondition or postcondition is provided; otherwise a plain Transition.
+   *
+   * @param {string} label - Transition label.
+   * @param {string|null} pre - Precondition expression or null.
+   * @param {string|null} post - Postcondition expression or null.
+   * @param {boolean} [silent=false] - Whether the transition is tau.
+   * @returns {string} Id of the new transition.
+   */
+  _addTransition(label, pre, post, silent = false) {
+    const id = this._uuid();
+    this._gridX += 80;
+    const pos = { x: this._gridX, y: this._gridY };
+    const t = (pre || post)
+      ? new DataAwareTransition(id, pos, label, 1, 0, pre || '', post || '', silent)
+      : new Transition(id, pos, label, 1, 0, silent);
+    this._dpn.addTransition(t);
+    return id;
+  }
+
+  /**
+   * Add a regular-type Arc with weight 1 between two DPN elements.
+   *
+   * @param {string} source - Source element id.
+   * @param {string} target - Target element id.
+   * @returns {string} Id of the new arc.
+   */
+  _addArc(source, target) {
+    const id = this._uuid();
+    this._dpn.addArc(new Arc(id, source, target, 1, 'regular'));
+    return id;
+  }
+
+  /**
+   * Generate a UUID v4 string.
+   *
+   * @returns {string} A freshly generated UUID.
+   */
+  _uuid() {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+      const r = Math.random() * 16 | 0;
+      const v = c === 'x' ? r : (r & 0x3 | 0x8);
+      return v.toString(16);
+    });
+  }
+}
+
+
+export { PythonToDPN };

--- a/src/extensions/python-import-dialog.js
+++ b/src/extensions/python-import-dialog.js
@@ -1,0 +1,585 @@
+import { PythonToDPN } from './python-dpn-transpiler.js';
+
+/**
+ * Library of example Python programs users can load into the editor.
+ */
+const PYTHON_EXAMPLES = [
+  {
+    name: 'Simple Counter',
+    description: 'Counts from 0 to 9',
+    code: `x = 0
+while x < 10:
+    x = x + 1`
+  },
+  {
+    name: 'If / Else Branching',
+    description: 'Conditional with two branches',
+    code: `x = 5
+if x > 3:
+    y = 1
+else:
+    y = 0`
+  },
+  {
+    name: 'Nested Loops',
+    description: 'Two nested for-range loops',
+    code: `total = 0
+for i in range(3):
+    for j in range(4):
+        total = total + 1`
+  },
+  {
+    name: 'Fibonacci',
+    description: 'Iterative Fibonacci sequence',
+    code: `a = 0
+b = 1
+n = 10
+i = 0
+while i < n:
+    temp = b
+    b = a + b
+    a = temp
+    i = i + 1`
+  },
+  {
+    name: 'Function Call',
+    description: 'Function definition and inlined call',
+    code: `def increment(v):
+    v = v + 1
+    return v
+
+x = 0
+increment(x)
+increment(x)`
+  },
+  {
+    name: 'GCD (Euclid)',
+    description: 'Greatest common divisor via subtraction',
+    code: `a = 48
+b = 18
+while a != b:
+    if a > b:
+        a = a - b
+    else:
+        b = b - a`
+  },
+  {
+    name: 'Mutual Exclusion',
+    description: 'Two-process flag-based mutex pattern',
+    code: `flag1 = 0
+flag2 = 0
+turn = 1
+
+# Process 1 enters
+flag1 = 1
+if flag2 == 0:
+    turn = 1
+    # critical section
+    flag1 = 0
+else:
+    flag1 = 0
+
+# Process 2 enters
+flag2 = 1
+if flag1 == 0:
+    turn = 2
+    # critical section
+    flag2 = 0
+else:
+    flag2 = 0`
+  },
+  {
+    name: 'Producer–Consumer',
+    description: 'Bounded-buffer produce/consume cycle',
+    code: `buffer = 0
+capacity = 5
+produced = 0
+consumed = 0
+
+while produced < 10:
+    if buffer < capacity:
+        buffer = buffer + 1
+        produced = produced + 1
+    if buffer > 0:
+        buffer = buffer - 1
+        consumed = consumed + 1`
+  },
+  {
+    name: 'Factorial',
+    description: 'Iterative factorial computation',
+    code: `n = 6
+result = 1
+i = 1
+while i <= n:
+    result = result * i
+    i = i + 1`
+  },
+  {
+    name: 'Bubble Sort Pass',
+    description: 'Single pass of bubble sort with swap flag',
+    code: `swapped = 1
+a = 5
+b = 3
+c = 8
+d = 1
+
+if a > b:
+    temp = a
+    a = b
+    b = temp
+    swapped = 1
+if b > c:
+    temp = b
+    b = c
+    c = temp
+    swapped = 1
+if c > d:
+    temp = c
+    c = d
+    d = temp
+    swapped = 1`
+  },
+  {
+    name: 'Traffic Light',
+    description: 'Cyclic state machine: red → green → yellow',
+    code: `state = 0
+cycles = 0
+while cycles < 3:
+    if state == 0:
+        state = 1
+    elif state == 1:
+        state = 2
+    elif state == 2:
+        state = 0
+        cycles = cycles + 1`
+  },
+  {
+    name: 'Break & Continue',
+    description: 'Loop with break and continue control flow',
+    code: `total = 0
+i = 0
+while i < 20:
+    i = i + 1
+    if i == 5:
+        continue
+    if i == 15:
+        break
+    total = total + i`
+  },
+];
+
+/**
+ * Unsupported Python constructs that the transpiler cannot translate.
+ * Each entry maps a human-readable label to a simple substring (or regex)
+ * that is tested against the raw source code.
+ */
+const UNSUPPORTED_CHECKS = [
+  { label: 'Class definitions (class)',              test: s => /^\s*class\s+/m.test(s) },
+  { label: 'Try / except blocks',                    test: s => /^\s*try\s*:/m.test(s) },
+  { label: 'With statements (context managers)',      test: s => /^\s*with\s+/m.test(s) },
+  { label: 'Import statements',                      test: s => /^\s*(import |from\s+\S+\s+import)/m.test(s) },
+  { label: 'Lambda expressions',                     test: s => /\blambda\b/.test(s) },
+  { label: 'List comprehensions',                    test: s => /\[\s*\S+.*\bfor\b.*\bin\b/.test(s) },
+  { label: 'Dict / set comprehensions',              test: s => /\{\s*\S+.*\bfor\b.*\bin\b/.test(s) },
+  { label: 'Generator expressions',                  test: s => /\(\s*\S+.*\bfor\b.*\bin\b/.test(s) },
+  { label: 'Async / await',                          test: s => /\basync\s+(def|for|with)\b/.test(s) },
+  { label: 'Yield statements (generators)',           test: s => /\byield\b/.test(s) },
+  { label: 'Global / nonlocal declarations',          test: s => /^\s*(global|nonlocal)\s+/m.test(s) },
+  { label: 'Decorators (@)',                          test: s => /^\s*@\w/m.test(s) },
+  { label: 'Starred expressions (*args, **kwargs)',   test: s => /\*\*\w|\*\w/.test(s) },
+  { label: 'Assert statements',                      test: s => /^\s*assert\s+/m.test(s) },
+  { label: 'Raise statements',                       test: s => /^\s*raise\s+/m.test(s) },
+  { label: 'Delete statements',                      test: s => /^\s*del\s+/m.test(s) },
+  { label: 'Modulo (%) / exponent (**) operators',    test: s => /%(?!=)|(?<!\*)\*\*(?!\*)/.test(s) },
+  { label: 'Slice notation (a[1:3])',                 test: s => /\w\[.*:.*\]/.test(s) },
+  { label: 'String operations (f-strings, .format)',  test: s => /f['"]|\.format\s*\(/.test(s) },
+  { label: 'Dictionary literals ({key: val})',        test: s => /\{[^}]*:[^}]*\}/.test(s) },
+];
+
+
+/**
+ * Modal dialog for importing Python source code as a Data Petri Net.
+ */
+export class PythonImportDialog {
+  /**
+   * @param {import('../petri-net-app.js').PetriNetApp} app
+   */
+  constructor(app) {
+    this._app = app;
+    this._overlay = null;
+    this._code = '';
+    this._mode = 'editor'; // 'editor' | 'file'
+  }
+
+  /** Open the dialog. */
+  open() {
+    if (this._overlay) return;
+    this._build();
+    document.body.appendChild(this._overlay);
+    // focus textarea in next tick
+    requestAnimationFrame(() => {
+      const ta = this._overlay.querySelector('#python-code-input');
+      if (ta) ta.focus();
+    });
+  }
+
+  /** Close and remove the dialog. */
+  close() {
+    if (this._overlay) {
+      this._overlay.remove();
+      this._overlay = null;
+    }
+  }
+
+  // ── private ──────────────────────────────────────────────────
+
+  _build() {
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+    overlay.addEventListener('click', e => { if (e.target === overlay) this.close(); });
+
+    overlay.innerHTML = `
+      <div class="modal-container python-import-container">
+        <div class="modal-header">
+          <h2>🐍 Import Python as DPN (⚠️ BETA)</h2>
+          <div class="modal-header-actions">
+            <button class="python-help-btn" title="Help">❓</button>
+            <button class="close-btn" title="Close">&times;</button>
+          </div>
+        </div>
+
+        <div class="modal-body">
+          <div class="python-import-content">
+
+            <!-- Help panel (hidden by default) -->
+            <div class="python-help-panel" id="python-help-panel" style="display:none">
+              <div class="python-help-section">
+                <h4>How to use</h4>
+                <ol>
+                  <li>Paste Python code in the editor or upload a <code>.py</code> file.</li>
+                  <li>Choose an example from the dropdown to get started quickly.</li>
+                  <li>Adjust <strong>Generalization</strong> (0 = exact model, higher = simpler) and <strong>Inlining Depth</strong> (levels of function inlining).</li>
+                  <li>Review warnings for unsupported constructs, then click <strong>Import</strong>.</li>
+                </ol>
+              </div>
+              <div class="python-help-section">
+                <h4>Supported constructs</h4>
+                <div class="python-help-columns">
+                  <div class="python-help-col">
+                    <h5>Statements</h5>
+                    <ul>
+                      <li><code>x = expr</code> — assignment</li>
+                      <li><code>x += expr</code> — augmented assignment (<code>+=</code>, <code>-=</code>, <code>*=</code>, <code>/=</code>)</li>
+                      <li><code>if / elif / else</code> — branching</li>
+                      <li><code>while cond:</code> — while loops</li>
+                      <li><code>for x in range(n):</code> — for-range loops</li>
+                      <li><code>def f(args):</code> — function definitions</li>
+                      <li><code>f(args)</code> — function calls (inlined)</li>
+                      <li><code>return expr</code></li>
+                      <li><code>break</code> / <code>continue</code></li>
+                      <li><code>pass</code></li>
+                    </ul>
+                  </div>
+                  <div class="python-help-col">
+                    <h5>Expressions &amp; operators</h5>
+                    <ul>
+                      <li>Arithmetic: <code>+</code> <code>-</code> <code>*</code> <code>/</code></li>
+                      <li>Comparison: <code>==</code> <code>!=</code> <code>&lt;</code> <code>&lt;=</code> <code>&gt;</code> <code>&gt;=</code></li>
+                      <li>Logical: <code>and</code> <code>or</code> <code>not</code></li>
+                      <li>Integer &amp; identifier literals</li>
+                      <li>Parenthesized sub-expressions</li>
+                      <li>Comments (<code>#</code>) are stripped</li>
+                    </ul>
+                    <h5>Translation model</h5>
+                    <ul>
+                      <li>Each statement becomes one or more transitions with guards (preconditions) and effects (postconditions).</li>
+                      <li>Variables become DPN data variables.</li>
+                      <li>Control flow (if/while/for) produces the corresponding Petri net routing pattern.</li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- Tab switcher -->
+            <div class="python-input-tabs">
+              <button class="python-tab-btn active" data-tab="editor">✏️ Code Editor</button>
+              <button class="python-tab-btn" data-tab="file">📂 Upload File</button>
+            </div>
+
+            <!-- Code editor pane -->
+            <div class="python-pane" data-pane="editor">
+              <div class="python-examples-bar">
+                <label for="python-example-select">📚 Examples:</label>
+                <select id="python-example-select">
+                  <option value="">— Select an example —</option>
+                  ${PYTHON_EXAMPLES.map((ex, i) =>
+                    `<option value="${i}">${ex.name} — ${ex.description}</option>`
+                  ).join('')}
+                </select>
+              </div>
+              <div class="python-code-editor">
+                <textarea id="python-code-input"
+                  spellcheck="false"
+                  placeholder="# Paste your Python code here…\nx = 0\nwhile x < 10:\n    x = x + 1"></textarea>
+                <span class="python-line-count" id="python-line-count">0 lines</span>
+              </div>
+            </div>
+
+            <!-- File upload pane (hidden initially) -->
+            <div class="python-pane" data-pane="file" style="display:none">
+              <div class="python-upload-area" id="python-upload-area">
+                <span class="python-upload-icon">📄</span>
+                <p>Drop a <strong>.py</strong> file here or <strong>click to browse</strong></p>
+                <span class="python-upload-info">Accepts *.py files</span>
+                <input type="file" accept=".py" style="display:none" id="python-file-input">
+              </div>
+              <div id="python-file-info" style="display:none"></div>
+            </div>
+
+            <!-- Warnings -->
+            <div class="python-warnings" id="python-warnings" style="display:none">
+              <div class="python-warnings-header">⚠️ Unsupported constructs detected</div>
+              <ul class="python-warnings-list" id="python-warnings-list"></ul>
+            </div>
+
+            <!-- Settings -->
+            <div class="python-settings">
+              <h3>⚙️ Translation Settings</h3>
+              <div class="python-settings-grid">
+                <div class="python-setting-item">
+                  <label>Generalization</label>
+                  <span class="setting-description">0 = exact; higher drops guards &amp; effects</span>
+                  <input type="range" id="python-gen" min="0" max="1" step="0.1" value="0">
+                  <span class="python-range-value" id="python-gen-value">0</span>
+                </div>
+                <div class="python-setting-item">
+                  <label>Inlining Depth</label>
+                  <span class="setting-description">Levels of function-call inlining</span>
+                  <input type="range" id="python-depth" min="0" max="5" step="1" value="1">
+                  <span class="python-range-value" id="python-depth-value">1</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Quick summary -->
+            <div class="python-summary" id="python-summary" style="display:none">
+              <span class="stat-item">Places: <span class="stat-value" id="python-stat-places">0</span></span>
+              <span class="stat-item">Transitions: <span class="stat-value" id="python-stat-transitions">0</span></span>
+              <span class="stat-item">Variables: <span class="stat-value" id="python-stat-vars">0</span></span>
+            </div>
+
+          </div>
+        </div>
+
+        <div class="modal-footer">
+          <button class="python-btn-cancel">Cancel</button>
+          <button class="python-btn-import" id="python-btn-import" disabled>Import</button>
+        </div>
+      </div>
+    `;
+
+    this._overlay = overlay;
+    this._wire(overlay);
+  }
+
+  _wire(root) {
+    // Close
+    root.querySelector('.close-btn').addEventListener('click', () => this.close());
+    root.querySelector('.python-btn-cancel').addEventListener('click', () => this.close());
+
+    // Help toggle
+    const helpBtn = root.querySelector('.python-help-btn');
+    const helpPanel = root.querySelector('#python-help-panel');
+    helpBtn.addEventListener('click', () => {
+      const open = helpPanel.style.display !== 'none';
+      helpPanel.style.display = open ? 'none' : '';
+      helpBtn.classList.toggle('active', !open);
+    });
+    document.addEventListener('keydown', this._escHandler = e => {
+      if (e.key === 'Escape') this.close();
+    });
+
+    // Tabs
+    const tabs = root.querySelectorAll('.python-tab-btn');
+    const panes = root.querySelectorAll('.python-pane');
+    tabs.forEach(btn => {
+      btn.addEventListener('click', () => {
+        tabs.forEach(t => t.classList.remove('active'));
+        btn.classList.add('active');
+        const target = btn.dataset.tab;
+        panes.forEach(p => p.style.display = p.dataset.pane === target ? '' : 'none');
+        this._mode = target;
+      });
+    });
+
+    // Textarea
+    const textarea = root.querySelector('#python-code-input');
+    const lineCount = root.querySelector('#python-line-count');
+    const onCodeChange = () => {
+      this._code = textarea.value;
+      const lines = (this._code.match(/\n/g) || []).length + (this._code.length ? 1 : 0);
+      lineCount.textContent = `${lines} line${lines !== 1 ? 's' : ''}`;
+      this._analyze();
+    };
+    textarea.addEventListener('input', onCodeChange);
+
+    // Example selector
+    const exampleSelect = root.querySelector('#python-example-select');
+    exampleSelect.addEventListener('change', () => {
+      const idx = exampleSelect.value;
+      if (idx === '') return;
+      const ex = PYTHON_EXAMPLES[parseInt(idx, 10)];
+      if (ex) {
+        textarea.value = ex.code;
+        onCodeChange();
+      }
+    });
+    // Allow Tab inside textarea
+    textarea.addEventListener('keydown', e => {
+      if (e.key === 'Tab') {
+        e.preventDefault();
+        const start = textarea.selectionStart;
+        const end = textarea.selectionEnd;
+        textarea.value = textarea.value.substring(0, start) + '    ' + textarea.value.substring(end);
+        textarea.selectionStart = textarea.selectionEnd = start + 4;
+        onCodeChange();
+      }
+    });
+
+    // File upload
+    const uploadArea = root.querySelector('#python-upload-area');
+    const fileInput = root.querySelector('#python-file-input');
+    const fileInfo = root.querySelector('#python-file-info');
+
+    uploadArea.addEventListener('click', () => fileInput.click());
+    uploadArea.addEventListener('dragover', e => { e.preventDefault(); uploadArea.classList.add('drag-over'); });
+    uploadArea.addEventListener('dragleave', () => uploadArea.classList.remove('drag-over'));
+    uploadArea.addEventListener('drop', e => {
+      e.preventDefault();
+      uploadArea.classList.remove('drag-over');
+      const file = e.dataTransfer.files[0];
+      if (file) this._loadFile(file, uploadArea, fileInfo);
+    });
+    fileInput.addEventListener('change', () => {
+      const file = fileInput.files[0];
+      if (file) this._loadFile(file, uploadArea, fileInfo);
+    });
+
+    // Settings sliders
+    const genSlider = root.querySelector('#python-gen');
+    const genValue = root.querySelector('#python-gen-value');
+    genSlider.addEventListener('input', () => { genValue.textContent = genSlider.value; });
+
+    const depthSlider = root.querySelector('#python-depth');
+    const depthValue = root.querySelector('#python-depth-value');
+    depthSlider.addEventListener('input', () => { depthValue.textContent = depthSlider.value; });
+
+    // Import
+    root.querySelector('#python-btn-import').addEventListener('click', () => this._doImport());
+  }
+
+  _loadFile(file, uploadArea, fileInfo) {
+    if (!file.name.endsWith('.py')) {
+      alert('Please select a .py file.');
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      this._code = e.target.result;
+      uploadArea.style.display = 'none';
+      fileInfo.style.display = '';
+      fileInfo.innerHTML = `
+        <div class="python-file-loaded">
+          <span>📄 ${this._escapeHtml(file.name)}</span>
+          <span style="color:#D8DEE9">(${(file.size / 1024).toFixed(1)} KB)</span>
+          <button class="file-remove" title="Remove file">&times;</button>
+        </div>
+      `;
+      fileInfo.querySelector('.file-remove').addEventListener('click', () => {
+        this._code = '';
+        fileInfo.style.display = 'none';
+        uploadArea.style.display = '';
+        this._analyze();
+      });
+      this._analyze();
+    };
+    reader.readAsText(file);
+  }
+
+  /** Check for unsupported constructs and update warnings + summary. */
+  _analyze() {
+    const code = this._code;
+    const importBtn = this._overlay.querySelector('#python-btn-import');
+    const warningsBox = this._overlay.querySelector('#python-warnings');
+    const warningsList = this._overlay.querySelector('#python-warnings-list');
+    const summary = this._overlay.querySelector('#python-summary');
+
+    if (!code.trim()) {
+      importBtn.disabled = true;
+      warningsBox.style.display = 'none';
+      summary.style.display = 'none';
+      return;
+    }
+
+    importBtn.disabled = false;
+
+    // Warnings
+    const hits = UNSUPPORTED_CHECKS.filter(c => c.test(code));
+    if (hits.length > 0) {
+      warningsBox.style.display = '';
+      warningsList.innerHTML = hits.map(h =>
+        `<li>${this._escapeHtml(h.label)}</li>`
+      ).join('');
+    } else {
+      warningsBox.style.display = 'none';
+    }
+
+    // Quick dry-run to count elements
+    try {
+      const gen = parseFloat(this._overlay.querySelector('#python-gen').value);
+      const depth = parseInt(this._overlay.querySelector('#python-depth').value, 10);
+      const transpiler = new PythonToDPN({ generalization: gen, depth });
+      const dpn = transpiler.convert(code);
+      const json = JSON.parse(dpn.toJSON());
+
+      summary.style.display = '';
+      this._overlay.querySelector('#python-stat-places').textContent = json.places.length;
+      this._overlay.querySelector('#python-stat-transitions').textContent = json.transitions.length;
+      this._overlay.querySelector('#python-stat-vars').textContent = (json.dataVariables || []).length;
+    } catch {
+      summary.style.display = 'none';
+    }
+  }
+
+  /** Run the transpiler and load the result into the editor. */
+  _doImport() {
+    const code = this._code;
+    if (!code.trim()) return;
+
+    const gen = parseFloat(this._overlay.querySelector('#python-gen').value);
+    const depth = parseInt(this._overlay.querySelector('#python-depth').value, 10);
+
+    try {
+      const transpiler = new PythonToDPN({ generalization: gen, depth });
+      const dpn = transpiler.convert(code);
+      const jsonStr = dpn.toJSON();
+
+      // Wrap as a File so the existing (possibly DPN-patched) loadFromFile handles it
+      const blob = new Blob([jsonStr], { type: 'application/json' });
+      const file = new File([blob], 'python-import.json', { type: 'application/json' });
+      this._app.loadFromFile(file);
+
+      this.close();
+    } catch (err) {
+      console.error('Python import failed:', err);
+      alert('Import failed: ' + err.message);
+    }
+  }
+
+  _escapeHtml(str) {
+    const d = document.createElement('div');
+    d.textContent = str;
+    return d.innerHTML;
+  }
+}

--- a/src/extensions/soundness-verification/suvorov-lomazova/smt-generator.js
+++ b/src/extensions/soundness-verification/suvorov-lomazova/smt-generator.js
@@ -2,6 +2,9 @@
  * Suvorov–Lomazova Data Petri Net Soundness Verifier
  * Refactored to use SMT-based verification with SmtFromDpnGenerator integration
  */
+import { parse } from '../../guard-language/guard-parser.js';
+import { toSmtLib2, toSmtLib2ForTau, extractWrittenVars } from '../../guard-language/guard-smt-emitter.js';
+
 class SmtFromDpnGenerator {
   /**
    * Generate an SMT-LIB2 encoding aligned with the paper’s step semantics.
@@ -418,25 +421,36 @@ class SmtFromDpnGenerator {
     const pre =
       this._rewriteGuard(preStr, i, dataVarsList, /*isPost=*/ false) || "true";
 
-    // Identify written variables (v' occurs in post)
+    // Identify written variables
     const writes = this._writtenVars(postStr, dataVarsList);
 
-    // Replace each v' in post with its bound write symbol W_v; then map reads to step i
-    let postBody = String(postStr || "").trim();
-    for (const [vName] of dataVarsList) {
-      const rePrime = new RegExp(`\\b${this._escapeReg(vName)}\\s*'`, "g");
-      postBody = postBody.replace(rePrime, this._wVar(vName)); // v' → v_w (bound name)
+    // For postBody, use toSmtLib2ForTau which maps primed vars to _w bound vars
+    let post = "true";
+    const postTrimmed = String(postStr || "").trim();
+    if (postTrimmed) {
+      try {
+        const { ast: postAst } = parse(postTrimmed, { isPostcondition: true });
+        if (postAst) {
+          post = toSmtLib2ForTau(postAst, i, dataVarsList, (x) => this._sym(x));
+        }
+      } catch (e) {
+        console.warn(`[SMT] Failed to parse postcondition for τ-guard: ${e.message}`);
+        // Fallback: manually replace primed vars and rewrite
+        let postBody = postTrimmed;
+        for (const [vName] of dataVarsList) {
+          const rePrime = new RegExp(`\\b${this._escapeReg(vName)}\\s*'`, "g");
+          postBody = postBody.replace(rePrime, this._wVar(vName));
+        }
+        post = this._rewriteGuard(postBody, i, dataVarsList, false) || "true";
+      }
     }
-    const post =
-      this._rewriteGuard(postBody, i, dataVarsList, /*isPost=*/ false) ||
-      "true";
 
     // Simple simplifications when no writes are present
     if (writes.size === 0) {
-      if (pre === "true" && post === "true") return "false"; // ¬(true ∧ true)
-      if (post === "true") return `(not ${pre})`; // ¬(pre)
-      if (pre === "true") return `(not ${post})`; // ¬(post)
-      return `(not (and ${pre} ${post}))`; // ¬(pre ∧ post)
+      if (pre === "true" && post === "true") return "false";
+      if (post === "true") return `(not ${pre})`;
+      if (pre === "true") return `(not ${post})`;
+      return `(not (and ${pre} ${post}))`;
     }
 
     // Build ∃W_t. (pre ∧ post) where W_t = { v_w | v ∈ writes }
@@ -444,9 +458,8 @@ class SmtFromDpnGenerator {
     for (const [vName, sort] of dataVarsList) {
       if (writes.has(vName)) boundDecls.push(`(${this._wVar(vName)} ${sort})`);
     }
-    const decls = boundDecls.length ? boundDecls.join(" ") : "(dummy_w Int)"; // should not happen because writes.size>0
+    const decls = boundDecls.length ? boundDecls.join(" ") : "(dummy_w Int)";
 
-    // (not (exists (W_t) (and pre post)))
     return `(not (exists (${decls}) (and ${pre} ${post})))`;
   }
 
@@ -464,23 +477,24 @@ class SmtFromDpnGenerator {
   _rewriteGuard(guardStr, i, dataVarsList, isPost) {
     const s = String(guardStr || "").trim();
     if (!s) return "";
-    const withVars = this._applyStepVars(s, i, dataVarsList, isPost);
-    if (/^\s*\(/.test(withVars)) return withVars;
-    return this._infixToSmt(withVars);
+    try {
+      const { ast } = parse(s, { isPostcondition: isPost });
+      if (!ast) return "";
+      return toSmtLib2(ast, i, dataVarsList, isPost, (x) => this._sym(x));
+    } catch (e) {
+      console.warn(`[SMT] Failed to parse guard "${s}": ${e.message}. Using fallback.`);
+      // Fallback: return the string with basic variable stepping
+      const withVars = this._applyStepVarsLegacy(s, i, dataVarsList, isPost);
+      return withVars;
+    }
   }
 
   /**
-   * Replace variable names with per-step symbols, handling primed writes (x') robustly.
-   * Ensures patterns like "x'","x'=", "x' +", "x' >" are correctly replaced.
-   *
-   * @param {string} s - Input string.
-   * @param {number} i - Step index.
-   * @param {Array<[string, string]>} dataVarsList - List of [varName, sort].
-   * @param {boolean} isPost - Whether this is a postcondition.
-   * @returns {string} String with variables stepped, no apostrophes left for known variables.
+   * Legacy fallback: replace variable names with per-step symbols.
+   * Only used when the parser fails on malformed input.
    * @private
    */
-  _applyStepVars(s, i, dataVarsList, isPost) {
+  _applyStepVarsLegacy(s, i, dataVarsList, isPost) {
     let r = ` ${s} `;
     r = r.replace(/\btrue\b/gi, "true").replace(/\bfalse\b/gi, "false");
 
@@ -500,102 +514,6 @@ class SmtFromDpnGenerator {
   }
 
   /**
-   * Convert a minimal infix boolean/arithmetic comparison string into SMT-LIB2 prefix form.
-   * Supports: and, or, not, parentheses, binary comparators (=,!=,<,<=,>,>=).
-   *
-   * @param {string} expr - Infix-like expression.
-   * @returns {string} SMT-LIB2 s-expression.
-   * @private
-   */
-  _infixToSmt(expr) {
-    const e = String(expr || "").trim();
-    if (!e) return "";
-    const norm = e
-      .replace(/\s+/g, " ")
-      .replace(/\band\b/gi, "and")
-      .replace(/\bor\b/gi, "or")
-      .replace(/\bnot\b/gi, "not");
-
-    const isAtom = (s) =>
-      /^[A-Za-z_][A-Za-z0-9_]*$/.test(s) ||
-      /^[-+]?\d+(?:\.\d+)?$/.test(s) ||
-      s === "true" ||
-      s === "false";
-
-    const stripOuter = (s) => {
-      let t = String(s || "").trim();
-      const balanced = (x) => {
-        let d = 0;
-        for (const ch of x) {
-          if (ch === "(") d++;
-          else if (ch === ")") d--;
-          if (d < 0) return false;
-        }
-        return d === 0;
-      };
-      while (t.startsWith("(") && t.endsWith(")") && balanced(t)) {
-        const inner = t.slice(1, -1).trim();
-        if (!inner.startsWith("(") || !inner.endsWith(")")) {
-          // only strip once if inner isn't also wrapped
-          t = inner;
-          break;
-        }
-        t = inner;
-      }
-      return t;
-    };
-
-    const splitTop = (s, op) => {
-      const parts = [];
-      let depth = 0,
-        buf = [];
-      const tokens = s.split(" ");
-      for (let i = 0; i < tokens.length; i++) {
-        const tok = tokens[i];
-        for (const ch of tok) {
-          if (ch === "(") depth++;
-          if (ch === ")") depth--;
-        }
-        if (depth === 0 && tok === op) {
-          parts.push(buf.join(" ").trim());
-          buf = [];
-        } else {
-          buf.push(tok);
-        }
-      }
-      const last = buf.join(" ").trim();
-      if (last) parts.push(last);
-      return parts;
-    };
-
-    const rec = (s) => {
-      const t = s.trim();
-      if (!t) return "true";
-      if (t.startsWith("(") && t.endsWith(")")) return rec(t.slice(1, -1));
-      const andParts = splitTop(t, "and");
-      if (andParts.length > 1) return `(and ${andParts.map(rec).join(" ")})`;
-      const orParts = splitTop(t, "or");
-      if (orParts.length > 1) return `(or ${orParts.map(rec).join(" ")})`;
-      if (t.startsWith("not ")) return `(not ${rec(t.slice(4))})`;
-      const cmp = t.match(/^(.+?)\s*(=|!=|<=|>=|<|>)\s*(.+)$/);
-      if (cmp) {
-        const lhs = rec(cmp[1]);
-        const rhs = rec(cmp[3]);
-        const op = cmp[2] === "!=" ? "distinct" : cmp[2];
-        if (op === "distinct") return `(distinct ${lhs} ${rhs})`;
-        if (["=", "<", "<=", ">", ">="].includes(op))
-          return `(${op} ${lhs} ${rhs})`;
-      }
-      return isAtom(t) ? t : t;
-    };
-
-    let res = rec(norm).replace(/\s+/g, " ").trim();
-    if (isAtom(res)) return res;
-    // Don't strip outer parens - they're part of the SMT-LIB2 syntax
-    return res.startsWith("(") ? res : `(${res})`;
-  }
-
-  /**
    * Compute the set of written variables (those with a primed occurrence) in a postcondition.
    *
    * @param {string} postStr - Postcondition string.
@@ -604,13 +522,20 @@ class SmtFromDpnGenerator {
    * @private
    */
   _writtenVars(postStr, dataVarsList) {
-    const set = new Set();
-    const s = String(postStr || "");
-    for (const [vName] of dataVarsList) {
-      if (new RegExp(`\\b${this._escapeReg(vName)}\\s*'`, "g").test(s))
-        set.add(vName);
+    const s = String(postStr || "").trim();
+    if (!s) return new Set();
+    try {
+      const { ast } = parse(s, { isPostcondition: true });
+      return extractWrittenVars(ast);
+    } catch {
+      // Fallback to regex-based detection
+      const set = new Set();
+      for (const [vName] of dataVarsList) {
+        if (new RegExp(`\\b${this._escapeReg(vName)}\\s*'`, "g").test(s))
+          set.add(vName);
+      }
+      return set;
     }
-    return set;
   }
 
   /**

--- a/src/extensions/soundness-verification/suvorov-lomazova/suvorov-lomazova-verifier.js
+++ b/src/extensions/soundness-verification/suvorov-lomazova/suvorov-lomazova-verifier.js
@@ -1,6 +1,8 @@
 import { SmtFromDpnGenerator } from './smt-generator.js';
 import { DPNRefinementEngine } from './DPN-refinement-engine.js';
 import { Z3Solver } from './z3-solver-wrapper.js';
+import { parse } from '../../guard-language/guard-parser.js';
+import { toSmtLib2 } from '../../guard-language/guard-smt-emitter.js';
 
 
 /**
@@ -317,9 +319,14 @@ checkDeadTransitions(dpn, lts) {
       if (!expr || expr === "true" || expr === "false") return expr || "true";
       // If already in SMT-LIB2 format (starts with '('), return as-is
       if (expr.trim().startsWith("(")) return expr;
-      // Otherwise, use the SmtFromDpnGenerator's conversion
-      const gen = new SmtFromDpnGenerator();
-      return gen._infixToSmt(expr);
+      // Use the guard language parser + SMT emitter
+      try {
+        const ast = parse(expr);
+        return toSmtLib2(ast);
+      } catch (e) {
+        console.warn("Guard parse failed, returning raw:", expr, e);
+        return expr;
+      }
     };
 
     for (const t of originalTransitions) {

--- a/src/petri-net-app.js
+++ b/src/petri-net-app.js
@@ -387,7 +387,7 @@ initEventHandlers() {
       this.performRedo();
       return;
     }
-    if (e.key === ' ' && this.editor && this.editor.mode !== 'addArc') {
+    if (e.key === ' ' && !isInputFocused && !document.querySelector('.modal-overlay') && this.editor && this.editor.mode !== 'addArc') {
       e.preventDefault();
       e.stopPropagation();
       this.editor.setMode('addArc');
@@ -396,7 +396,9 @@ initEventHandlers() {
   };
 
   const keyupHandler = (e) => {
-    if (e.key === ' ' && this.editor) {
+    const tag = document.activeElement?.tagName;
+    const isInputFocused = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+    if (e.key === ' ' && !isInputFocused && !document.querySelector('.modal-overlay') && this.editor) {
       e.preventDefault();
       e.stopPropagation();
       this.editor.setMode('select');

--- a/styles/dpn-styles.css
+++ b/styles/dpn-styles.css
@@ -971,6 +971,16 @@
   border-color: #88C0D0;
 }
 
+.expr-textarea-error {
+  border-color: #BF616A !important;
+  background-color: #2E3440;
+}
+
+.expr-textarea-error:focus {
+  border-color: #BF616A !important;
+  box-shadow: 0 0 0 2px rgba(191, 97, 106, 0.25);
+}
+
 .expr-textarea::placeholder {
   color: #4C566A;
 }

--- a/styles/python-importer.css
+++ b/styles/python-importer.css
@@ -1,0 +1,523 @@
+/**
+ * Python Importer Dialog Styles
+ * Nord-themed modal for importing Python code as Data Petri Nets
+ */
+
+/* Container */
+.python-import-container {
+  width: 90%;
+  max-width: 720px;
+  max-height: 90vh;
+  background-color: #3B4252; /* nord1 */
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+}
+
+.python-import-container .modal-header {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.modal-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.python-help-btn {
+  background: none;
+  border: 1px solid #4C566A;
+  color: #D8DEE9;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  cursor: pointer;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.python-help-btn:hover {
+  background-color: #434C5E;
+  border-color: #88C0D0;
+}
+
+.python-help-btn.active {
+  background-color: #434C5E;
+  border-color: #88C0D0;
+  color: #88C0D0;
+}
+
+.python-import-container .modal-body {
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+}
+
+.python-import-content {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+/* ── Help panel ── */
+.python-help-panel {
+  background-color: #2E3440;
+  border: 1px solid #4C566A;
+  border-radius: 6px;
+  padding: 16px 20px;
+  font-size: 13px;
+  color: #D8DEE9;
+  line-height: 1.6;
+}
+
+.python-help-section + .python-help-section {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid #3B4252;
+}
+
+.python-help-panel h4 {
+  margin: 0 0 8px 0;
+  font-size: 14px;
+  color: #88C0D0;
+  font-weight: 600;
+}
+
+.python-help-panel h5 {
+  margin: 10px 0 4px 0;
+  font-size: 13px;
+  color: #81A1C1;
+  font-weight: 600;
+}
+
+.python-help-panel ol,
+.python-help-panel ul {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.python-help-panel li {
+  margin-bottom: 3px;
+}
+
+.python-help-panel code {
+  background-color: #3B4252;
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 12px;
+  color: #A3BE8C;
+}
+
+.python-help-columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+@media (max-width: 600px) {
+  .python-help-columns {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Input mode tabs ── */
+.python-input-tabs {
+  display: flex;
+  gap: 0;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid #4C566A; /* nord3 */
+}
+
+.python-tab-btn {
+  flex: 1;
+  padding: 10px 16px;
+  background-color: #434C5E; /* nord2 */
+  color: #D8DEE9; /* nord4 */
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  transition: background-color 0.2s ease, color 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.python-tab-btn:hover {
+  background-color: #4C566A; /* nord3 */
+}
+
+.python-tab-btn.active {
+  background-color: #5E81AC; /* nord10 */
+  color: #ECEFF4; /* nord6 */
+}
+
+/* ── File upload area ── */
+.python-upload-area {
+  border: 2px dashed #88C0D0; /* nord8 */
+  border-radius: 8px;
+  padding: 36px 20px;
+  text-align: center;
+  background-color: #434C5E; /* nord2 */
+  cursor: pointer;
+  transition: all 0.3s ease;
+  position: relative;
+}
+
+.python-upload-area:hover {
+  border-color: #8FBCBB; /* nord7 */
+  background-color: #4C566A; /* nord3 */
+  transform: translateY(-2px);
+  box-shadow: 0 4px 20px rgba(136, 192, 208, 0.15);
+}
+
+.python-upload-area.drag-over {
+  border-color: #A3BE8C; /* nord14 */
+  background-color: rgba(163, 190, 140, 0.08);
+  border-style: solid;
+}
+
+.python-upload-icon {
+  font-size: 40px;
+  margin-bottom: 12px;
+  display: block;
+}
+
+.python-upload-area p {
+  margin: 0 0 8px 0;
+  font-size: 15px;
+  color: #E5E9F0; /* nord5 */
+}
+
+.python-upload-area strong {
+  color: #88C0D0; /* nord8 */
+  text-decoration: underline;
+}
+
+.python-upload-info {
+  font-size: 13px;
+  color: #D8DEE9; /* nord4 */
+  font-style: italic;
+}
+
+.python-file-loaded {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 14px;
+  background-color: rgba(163, 190, 140, 0.12);
+  border: 1px solid #A3BE8C; /* nord14 */
+  border-radius: 6px;
+  margin-top: 12px;
+  color: #A3BE8C;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.python-file-loaded .file-remove {
+  background: none;
+  border: none;
+  color: #BF616A; /* nord11 */
+  cursor: pointer;
+  font-size: 16px;
+  padding: 0 4px;
+  margin-left: 8px;
+  opacity: 0.7;
+  transition: opacity 0.2s;
+}
+
+.python-file-loaded .file-remove:hover {
+  opacity: 1;
+}
+
+/* ── Examples selector bar ── */
+.python-examples-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.python-examples-bar label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #E5E9F0; /* nord5 */
+  white-space: nowrap;
+}
+
+.python-examples-bar select {
+  flex: 1;
+  background-color: #434C5E; /* nord2 */
+  color: #ECEFF4; /* nord6 */
+  border: 1px solid #4C566A; /* nord3 */
+  border-radius: 5px;
+  padding: 7px 10px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: border-color 0.2s ease;
+}
+
+.python-examples-bar select:focus {
+  outline: none;
+  border-color: #88C0D0; /* nord8 */
+  box-shadow: 0 0 0 2px rgba(136, 192, 208, 0.2);
+}
+
+/* ── Code editor textarea ── */
+.python-code-editor {
+  position: relative;
+}
+
+.python-code-editor textarea {
+  width: 100%;
+  min-height: 220px;
+  max-height: 340px;
+  background-color: #2E3440; /* nord0 */
+  color: #D8DEE9; /* nord4 */
+  border: 1px solid #4C566A; /* nord3 */
+  border-radius: 6px;
+  padding: 14px;
+  font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  resize: vertical;
+  tab-size: 4;
+  white-space: pre;
+  overflow-wrap: normal;
+  overflow-x: auto;
+  box-sizing: border-box;
+}
+
+.python-code-editor textarea:focus {
+  outline: none;
+  border-color: #88C0D0; /* nord8 */
+  box-shadow: 0 0 0 2px rgba(136, 192, 208, 0.2);
+}
+
+.python-code-editor textarea::placeholder {
+  color: #4C566A; /* nord3 */
+  font-style: italic;
+}
+
+.python-line-count {
+  position: absolute;
+  bottom: 8px;
+  right: 12px;
+  font-size: 11px;
+  color: #4C566A; /* nord3 */
+  pointer-events: none;
+}
+
+/* ── Warnings panel ── */
+.python-warnings {
+  background-color: rgba(208, 135, 112, 0.1);
+  border: 1px solid #D08770; /* nord12 */
+  border-radius: 6px;
+  padding: 14px 16px;
+  border-left: 4px solid #D08770;
+}
+
+.python-warnings-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  font-weight: 600;
+  font-size: 14px;
+  color: #D08770; /* nord12 */
+}
+
+.python-warnings-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.python-warnings-list li {
+  font-size: 13px;
+  color: #D8DEE9; /* nord4 */
+  padding-left: 20px;
+  position: relative;
+}
+
+.python-warnings-list li::before {
+  content: '•';
+  position: absolute;
+  left: 6px;
+  color: #D08770; /* nord12 */
+}
+
+/* ── Settings section ── */
+.python-settings {
+  background-color: #434C5E; /* nord2 */
+  border-radius: 8px;
+  padding: 18px 20px;
+  border-left: 4px solid #81A1C1; /* nord9 */
+}
+
+.python-settings h3 {
+  margin: 0 0 16px 0;
+  color: #E5E9F0; /* nord5 */
+  font-size: 15px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.python-settings-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px;
+}
+
+.python-setting-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.python-setting-item label {
+  font-weight: 600;
+  color: #E5E9F0; /* nord5 */
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.python-setting-item .setting-description {
+  font-size: 11px;
+  color: #D8DEE9; /* nord4 */
+  font-style: italic;
+  margin-bottom: 2px;
+}
+
+.python-setting-item input[type="range"] {
+  width: 100%;
+  height: 6px;
+  background: #4C566A; /* nord3 */
+  border-radius: 3px;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+.python-setting-item input[type="range"]::-webkit-slider-thumb {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  background: #88C0D0; /* nord8 */
+  border-radius: 50%;
+  cursor: pointer;
+  border: 2px solid #ECEFF4; /* nord6 */
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  transition: all 0.15s ease;
+}
+
+.python-setting-item input[type="range"]::-webkit-slider-thumb:hover {
+  background: #8FBCBB; /* nord7 */
+  transform: scale(1.1);
+}
+
+.python-setting-item input[type="range"]::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  background: #88C0D0; /* nord8 */
+  border-radius: 50%;
+  cursor: pointer;
+  border: 2px solid #ECEFF4; /* nord6 */
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.python-range-value {
+  font-size: 12px;
+  color: #88C0D0; /* nord8 */
+  font-weight: 600;
+  text-align: center;
+  background-color: #4C566A; /* nord3 */
+  padding: 3px 8px;
+  border-radius: 4px;
+  min-width: 50px;
+  align-self: flex-start;
+}
+
+/* ── Summary bar ── */
+.python-summary {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  padding: 12px 16px;
+  background-color: #434C5E; /* nord2 */
+  border-radius: 6px;
+  font-size: 13px;
+  color: #D8DEE9; /* nord4 */
+}
+
+.python-summary .stat-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.python-summary .stat-value {
+  font-weight: 600;
+  color: #88C0D0; /* nord8 */
+}
+
+/* ── Footer buttons ── */
+.python-import-container .modal-footer {
+  flex-shrink: 0;
+}
+
+.python-import-container .modal-footer button {
+  padding: 9px 22px;
+  border-radius: 5px;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  transition: background-color 0.2s ease, transform 0.1s ease;
+}
+
+.python-import-container .modal-footer button:active {
+  transform: scale(0.97);
+}
+
+.python-btn-cancel {
+  background-color: #4C566A; /* nord3 */
+  color: #D8DEE9; /* nord4 */
+}
+
+.python-btn-cancel:hover {
+  background-color: #5a6577;
+}
+
+.python-btn-import {
+  background-color: #5E81AC; /* nord10 */
+  color: #ECEFF4; /* nord6 */
+}
+
+.python-btn-import:hover {
+  background-color: #6d8fb5;
+}
+
+.python-btn-import:disabled {
+  background-color: #4C566A; /* nord3 */
+  color: #616e7c;
+  cursor: not-allowed;
+}

--- a/tests/python-dpn-transpiler.js
+++ b/tests/python-dpn-transpiler.js
@@ -1,0 +1,757 @@
+import { DataPetriNet, DataAwareTransition, DataVariable } from './dpn-model.js';
+import { Place, Transition, Arc } from '../petri-net-simulator.js';
+
+
+/**
+ * Translate Python source code into a YAPNE-compatible Data Petri Net.
+ *
+ * The translation preserves recall of 1: every feasible execution trace of
+ * the input Python program corresponds to a firing sequence of the produced
+ * DPN. At generalization 0 precision is also 1, i.e. every firing sequence
+ * of the DPN matches some Python trace. Raising generalization progressively
+ * drops postconditions (variable effects) and then preconditions (branch
+ * guards), trading precision for a simpler model while preserving recall.
+ *
+ * Guard and postcondition syntax follows the restricted infix form of the
+ * YAPNE DPN grammar: operators `and`, `or`, `not`, `=`, `==`, `!=`, `<`,
+ * `<=`, `>`, `>=`, `+`, `-`, `*`, `/`, with primed identifiers (`v'`) for
+ * writes in postconditions and assignments separated by `;`.
+ */
+class PythonToDPN {
+  /**
+   * Create a new translator.
+   *
+   * @param {{generalization?: number, depth?: number, name?: string}} [options]
+   *   - generalization: number in [0, 1] controlling how aggressively guards
+   *     and effects are dropped. Values >= 0.4 drop postconditions; values
+   *     >= 0.8 additionally drop preconditions. Default 0 (exact translation).
+   *   - depth: maximum function-call inlining depth. 0 keeps every call as a
+   *     single opaque transition; n > 0 inlines up to n nested call levels.
+   *     Default 1.
+   *   - name: display name for the produced DataPetriNet. Default 'Python Program'.
+   */
+  constructor(options = {}) {
+    this.generalization = options.generalization ?? 0;
+    this.depth = options.depth ?? 1;
+    this.name = options.name ?? 'Python Program';
+  }
+
+  /**
+   * Convert a Python source string into a Data Petri Net.
+   *
+   * @param {string} code - Raw Python source code.
+   * @returns {DataPetriNet} A populated DataPetriNet instance. Call `.toJSON()`
+   *   on the result to persist it or import it into YAPNE.
+   */
+  convert(code) {
+    this._dpn = new DataPetriNet(this._uuid(), this.name, 'Generated from Python source');
+    this._variables = new Map();
+    this._functions = new Map();
+    this._loopStack = [];
+    this._callDepth = 0;
+    this._gridX = 0;
+    this._gridY = 0;
+
+    const topLevel = [];
+    for (const stmt of this._parseProgram(code)) {
+      if (stmt.kind === 'def') {
+        this._functions.set(stmt.name, stmt);
+      } else {
+        topLevel.push(stmt);
+      }
+    }
+
+    const start = this._addPlace('start', 1);
+    const exit = this._buildBlock(topLevel, start);
+    if (exit !== null) {
+      this._dpn.getPlace(exit).finalMarking = 1;
+    }
+
+    for (const [name, type] of this._variables) {
+      this._dpn.addDataVariable(
+        new DataVariable(this._uuid(), name, type, this._defaultValue(type))
+      );
+    }
+    return this._dpn;
+  }
+
+  /**
+   * Parse a full Python program into a list of top-level statement ASTs.
+   *
+   * @param {string} code - Raw Python source.
+   * @returns {Array<Object>} Parsed statement nodes.
+   */
+  _parseProgram(code) {
+    const lines = [];
+    for (const raw of code.split('\n')) {
+      const stripped = this._stripComment(raw);
+      if (stripped.trim() === '') continue;
+      const indent = stripped.length - stripped.trimStart().length;
+      lines.push({ indent: indent, text: stripped.trim() });
+    }
+    return this._parseBlock(lines, 0, 0).stmts;
+  }
+
+  /**
+   * Remove a trailing line comment from a Python source line, ignoring `#`
+   * characters that occur inside string literals.
+   *
+   * @param {string} line - A single line of Python source.
+   * @returns {string} The line without its trailing comment.
+   */
+  _stripComment(line) {
+    let inStr = null;
+    for (let i = 0; i < line.length; i++) {
+      const c = line[i];
+      if (inStr) {
+        if (c === inStr && line[i - 1] !== '\\') inStr = null;
+      } else if (c === '"' || c === "'") {
+        inStr = c;
+      } else if (c === '#') {
+        return line.substring(0, i);
+      }
+    }
+    return line;
+  }
+
+  /**
+   * Parse a contiguous block of statements at indentation >= `indent`.
+   *
+   * @param {Array<{indent: number, text: string}>} lines - Pre-tokenized lines.
+   * @param {number} start - Starting line index.
+   * @param {number} indent - Required minimum indentation for the block.
+   * @returns {{stmts: Array<Object>, nextIdx: number}} Parsed statements and
+   *   the index of the first line not belonging to the block.
+   */
+  _parseBlock(lines, start, indent) {
+    const stmts = [];
+    let i = start;
+    while (i < lines.length && lines[i].indent >= indent) {
+      if (lines[i].indent > indent) {
+        i++;
+        continue;
+      }
+      const { stmt, nextIdx } = this._parseStatement(lines, i);
+      if (stmt) stmts.push(stmt);
+      i = nextIdx;
+    }
+    return { stmts: stmts, nextIdx: i };
+  }
+
+  /**
+   * Parse a single statement starting at line index `idx`.
+   *
+   * @param {Array<{indent: number, text: string}>} lines - Pre-tokenized lines.
+   * @param {number} idx - Line index of the statement's first line.
+   * @returns {{stmt: Object|null, nextIdx: number}} Parsed AST node (or null
+   *   for an unrecognized line) and the index of the next unparsed line.
+   */
+  _parseStatement(lines, idx) {
+    const text = lines[idx].text;
+
+    if (text.startsWith('if ') && text.endsWith(':')) {
+      return this._parseIfChain(lines, idx);
+    }
+    if (text.startsWith('while ') && text.endsWith(':')) {
+      const cond = text.slice(6, -1).trim();
+      const child = this._childIndent(lines, idx);
+      const body = this._parseBlock(lines, idx + 1, child);
+      return { stmt: { kind: 'while', cond: cond, body: body.stmts }, nextIdx: body.nextIdx };
+    }
+    if (text.startsWith('for ')) {
+      const m = text.match(/^for\s+([A-Za-z_]\w*)\s+in\s+(.+):$/);
+      if (m) {
+        const child = this._childIndent(lines, idx);
+        const body = this._parseBlock(lines, idx + 1, child);
+        return {
+          stmt: { kind: 'for', variable: m[1], iterable: m[2].trim(), body: body.stmts },
+          nextIdx: body.nextIdx
+        };
+      }
+    }
+    if (text.startsWith('def ')) {
+      const m = text.match(/^def\s+([A-Za-z_]\w*)\s*\(([^)]*)\)\s*:$/);
+      if (m) {
+        const child = this._childIndent(lines, idx);
+        const body = this._parseBlock(lines, idx + 1, child);
+        const params = m[2].split(',').map(p => p.trim()).filter(p => p.length > 0);
+        return {
+          stmt: { kind: 'def', name: m[1], params: params, body: body.stmts },
+          nextIdx: body.nextIdx
+        };
+      }
+    }
+    if (text === 'return' || text.startsWith('return ')) {
+      const expr = text === 'return' ? null : text.slice(7).trim();
+      return { stmt: { kind: 'return', expr: expr }, nextIdx: idx + 1 };
+    }
+    if (text === 'pass')     return { stmt: { kind: 'pass' },     nextIdx: idx + 1 };
+    if (text === 'break')    return { stmt: { kind: 'break' },    nextIdx: idx + 1 };
+    if (text === 'continue') return { stmt: { kind: 'continue' }, nextIdx: idx + 1 };
+
+    const aug = text.match(/^([A-Za-z_]\w*)\s*(\+=|-=|\*=|\/=)\s*(.+)$/);
+    if (aug) {
+      return {
+        stmt: { kind: 'assign', variable: aug[1], op: aug[2], expr: aug[3].trim() },
+        nextIdx: idx + 1
+      };
+    }
+
+    const assign = text.match(/^([A-Za-z_]\w*)\s*=(?!=)\s*(.+)$/);
+    if (assign) {
+      return {
+        stmt: { kind: 'assign', variable: assign[1], op: '=', expr: assign[2].trim() },
+        nextIdx: idx + 1
+      };
+    }
+
+    const call = this._matchPureCall(text);
+    if (call) {
+      return { stmt: { kind: 'call', name: call.name, args: call.args }, nextIdx: idx + 1 };
+    }
+
+    return { stmt: { kind: 'expr', text: text }, nextIdx: idx + 1 };
+  }
+
+  /**
+   * Parse an if/elif+/else chain into a right-nested if AST.
+   *
+   * @param {Array<{indent: number, text: string}>} lines - Pre-tokenized lines.
+   * @param {number} idx - Line index of the `if` header.
+   * @returns {{stmt: Object, nextIdx: number}} The nested if AST and the next index.
+   */
+  _parseIfChain(lines, idx) {
+    const own = lines[idx].indent;
+    const branches = [];
+
+    const firstCond = lines[idx].text.slice(3, -1).trim();
+    const firstChild = this._childIndent(lines, idx);
+    const firstBody = this._parseBlock(lines, idx + 1, firstChild);
+    branches.push({ cond: firstCond, body: firstBody.stmts });
+    let i = firstBody.nextIdx;
+
+    while (i < lines.length && lines[i].indent === own) {
+      const t = lines[i].text;
+      if (t.startsWith('elif ') && t.endsWith(':')) {
+        const c = t.slice(5, -1).trim();
+        const ci = this._childIndent(lines, i);
+        const b = this._parseBlock(lines, i + 1, ci);
+        branches.push({ cond: c, body: b.stmts });
+        i = b.nextIdx;
+      } else if (t === 'else:') {
+        const ci = this._childIndent(lines, i);
+        const b = this._parseBlock(lines, i + 1, ci);
+        branches.push({ cond: null, body: b.stmts });
+        i = b.nextIdx;
+        break;
+      } else {
+        break;
+      }
+    }
+
+    let elseBody = [];
+    if (branches[branches.length - 1].cond === null) {
+      elseBody = branches.pop().body;
+    }
+    let result = elseBody;
+    for (let k = branches.length - 1; k >= 0; k--) {
+      result = [{
+        kind: 'if',
+        cond: branches[k].cond,
+        thenBody: branches[k].body,
+        elseBody: result
+      }];
+    }
+    return { stmt: result[0], nextIdx: i };
+  }
+
+  /**
+   * Determine the indentation level of the block following a header line.
+   *
+   * @param {Array<{indent: number, text: string}>} lines - Pre-tokenized lines.
+   * @param {number} idx - Index of the header line (e.g. an `if x:` line).
+   * @returns {number} Indentation of the child block, or the header's indent + 4
+   *   when the child block is empty.
+   */
+  _childIndent(lines, idx) {
+    if (idx + 1 < lines.length && lines[idx + 1].indent > lines[idx].indent) {
+      return lines[idx + 1].indent;
+    }
+    return lines[idx].indent + 4;
+  }
+
+  /**
+   * Match a statement that is exactly a single function call with balanced parentheses.
+   *
+   * @param {string} text - The trimmed statement line.
+   * @returns {{name: string, args: string}|null} Name and raw argument string,
+   *   or null if the line is not a pure call.
+   */
+  _matchPureCall(text) {
+    const head = text.match(/^([A-Za-z_]\w*)\s*\(/);
+    if (!head) return null;
+    let depth = 1;
+    let i = head[0].length;
+    while (i < text.length && depth > 0) {
+      const c = text[i];
+      if (c === '(') depth++;
+      else if (c === ')') depth--;
+      i++;
+    }
+    if (depth !== 0 || i !== text.length) return null;
+    return { name: head[1], args: text.substring(head[0].length, i - 1) };
+  }
+
+  /**
+   * Build the DPN sub-graph for a sequence of statements.
+   *
+   * @param {Array<Object>} stmts - Statement AST nodes.
+   * @param {string} entry - Id of the place where control enters the block.
+   * @returns {string|null} Id of the exit place, or null when control does
+   *   not fall through (after a return, break, or continue).
+   */
+  _buildBlock(stmts, entry) {
+    let cur = entry;
+    for (const s of stmts) {
+      if (cur === null) break;
+      cur = this._buildStmt(s, cur);
+    }
+    return cur;
+  }
+
+  /**
+   * Dispatch to the builder for a single statement.
+   *
+   * @param {Object} stmt - Statement AST node.
+   * @param {string} entry - Entry place id.
+   * @returns {string|null} Exit place id, or null for non-falling-through statements.
+   */
+  _buildStmt(stmt, entry) {
+    switch (stmt.kind) {
+      case 'assign':   return this._buildAssign(stmt, entry);
+      case 'if':       return this._buildIf(stmt, entry);
+      case 'while':    return this._buildWhile(stmt, entry);
+      case 'for':      return this._buildFor(stmt, entry);
+      case 'call':     return this._buildCall(stmt, entry);
+      case 'return':   return this._buildReturn(stmt, entry);
+      case 'pass':     return entry;
+      case 'break':    return this._buildJump(entry, 'break');
+      case 'continue': return this._buildJump(entry, 'continue');
+      case 'expr':     return this._buildOpaque(stmt.text, entry);
+      default:         return entry;
+    }
+  }
+
+  /**
+   * Emit a transition encoding a Python assignment `x = rhs` or augmented form.
+   *
+   * @param {{variable: string, op: string, expr: string}} stmt - Assignment AST.
+   * @param {string} entry - Entry place id.
+   * @returns {string} Exit place id.
+   */
+  _buildAssign(stmt, entry) {
+    this._ensureVariable(stmt.variable, this._inferType(stmt.expr));
+    const rhs = this._translateExpr(stmt.expr);
+    let post = null;
+    if (this._isSupported(rhs)) {
+      const body = stmt.op === '='
+        ? rhs
+        : `${stmt.variable} ${stmt.op[0]} (${rhs})`;
+      post = `${stmt.variable}' = ${body}`;
+    }
+    const label = `${stmt.variable} ${stmt.op} ${stmt.expr}`;
+    const next = this._addPlace('');
+    const t = this._addTransition(label, null, this._generalizePost(post), false);
+    this._addArc(entry, t);
+    this._addArc(t, next);
+    return next;
+  }
+
+  /**
+   * Emit the branching structure for a Python if/else statement.
+   *
+   * @param {{cond: string, thenBody: Array<Object>, elseBody: Array<Object>}} stmt - If AST.
+   * @param {string} entry - Entry place id.
+   * @returns {string} Id of the merge place where both branches rejoin.
+   */
+  _buildIf(stmt, entry) {
+    const cond = this._translateExpr(stmt.cond);
+    const pre = this._isSupported(cond) ? cond : null;
+    const negPre = pre === null ? null : `not (${pre})`;
+    const merge = this._addPlace('');
+
+    const thenEntry = this._addPlace('');
+    const tThen = this._addTransition('[then]', this._generalizePre(pre), null, true);
+    this._addArc(entry, tThen);
+    this._addArc(tThen, thenEntry);
+    const thenExit = this._buildBlock(stmt.thenBody, thenEntry);
+    if (thenExit !== null) {
+      const tj = this._addTransition('', null, null, true);
+      this._addArc(thenExit, tj);
+      this._addArc(tj, merge);
+    }
+
+    const elseEntry = this._addPlace('');
+    const tElse = this._addTransition('[else]', this._generalizePre(negPre), null, true);
+    this._addArc(entry, tElse);
+    this._addArc(tElse, elseEntry);
+    const elseExit = this._buildBlock(stmt.elseBody, elseEntry);
+    if (elseExit !== null) {
+      const tj = this._addTransition('', null, null, true);
+      this._addArc(elseExit, tj);
+      this._addArc(tj, merge);
+    }
+
+    return merge;
+  }
+
+  /**
+   * Emit a loop structure for a Python while statement. The entry place
+   * doubles as the loop header so continue-edges can reuse it.
+   *
+   * @param {{cond: string, body: Array<Object>}} stmt - While AST.
+   * @param {string} entry - Entry place id, reused as the loop header.
+   * @returns {string} Id of the loop's exit place.
+   */
+  _buildWhile(stmt, entry) {
+    const cond = this._translateExpr(stmt.cond);
+    const pre = this._isSupported(cond) ? cond : null;
+    const negPre = pre === null ? null : `not (${pre})`;
+
+    const bodyEntry = this._addPlace('');
+    const exitPlace = this._addPlace('');
+
+    const tEnter = this._addTransition('[while-enter]', this._generalizePre(pre), null, true);
+    this._addArc(entry, tEnter);
+    this._addArc(tEnter, bodyEntry);
+
+    const tExit = this._addTransition('[while-exit]', this._generalizePre(negPre), null, true);
+    this._addArc(entry, tExit);
+    this._addArc(tExit, exitPlace);
+
+    this._loopStack.push({ back: entry, exit: exitPlace });
+    const bodyExit = this._buildBlock(stmt.body, bodyEntry);
+    this._loopStack.pop();
+
+    if (bodyExit !== null) {
+      const tBack = this._addTransition('', null, null, true);
+      this._addArc(bodyExit, tBack);
+      this._addArc(tBack, entry);
+    }
+    return exitPlace;
+  }
+
+  /**
+   * Emit a loop for `for v in range(...)`. Other iterables collapse to an
+   * opaque transition.
+   *
+   * @param {{variable: string, iterable: string, body: Array<Object>}} stmt - For AST.
+   * @param {string} entry - Entry place id.
+   * @returns {string} Exit place id after the loop.
+   */
+  _buildFor(stmt, entry) {
+    const m = stmt.iterable.match(
+      /^range\s*\(\s*([^,)]+)(?:\s*,\s*([^,)]+))?(?:\s*,\s*([^)]+))?\s*\)$/
+    );
+    if (m) {
+      const startExpr = m[2] ? m[1].trim() : '0';
+      const endExpr = m[2] ? m[2].trim() : m[1].trim();
+      const stepExpr = m[3] ? m[3].trim() : '1';
+      this._ensureVariable(stmt.variable, 'int');
+      const init = { kind: 'assign', variable: stmt.variable, op: '=', expr: startExpr };
+      const inc = {
+        kind: 'assign',
+        variable: stmt.variable,
+        op: '=',
+        expr: `${stmt.variable} + ${stepExpr}`
+      };
+      const whileStmt = {
+        kind: 'while',
+        cond: `${stmt.variable} < ${endExpr}`,
+        body: stmt.body.concat([inc])
+      };
+      const afterInit = this._buildAssign(init, entry);
+      return this._buildWhile(whileStmt, afterInit);
+    }
+    return this._buildOpaque(`for ${stmt.variable} in ${stmt.iterable}`, entry);
+  }
+
+  /**
+   * Emit a function call, either inlining the body (when the function is
+   * known and current depth permits) or as a single opaque transition.
+   *
+   * @param {{name: string, args: string}} stmt - Call AST.
+   * @param {string} entry - Entry place id.
+   * @returns {string} Exit place id after the call.
+   */
+  _buildCall(stmt, entry) {
+    const fn = this._functions.get(stmt.name);
+    if (fn && this._callDepth < this.depth) {
+      let cur = entry;
+      if (fn.params.length > 0) {
+        const args = this._splitArgs(stmt.args);
+        const clauses = [];
+        for (let i = 0; i < Math.min(fn.params.length, args.length); i++) {
+          const p = fn.params[i];
+          const a = args[i];
+          this._ensureVariable(p, this._inferType(a));
+          const rhs = this._translateExpr(a);
+          if (this._isSupported(rhs)) clauses.push(`${p}' = ${rhs}`);
+        }
+        if (clauses.length > 0) {
+          const bind = this._addTransition(
+            `[call ${stmt.name}]`,
+            null,
+            this._generalizePost(clauses.join('; ')),
+            true
+          );
+          const after = this._addPlace('');
+          this._addArc(cur, bind);
+          this._addArc(bind, after);
+          cur = after;
+        }
+      }
+      this._callDepth++;
+      const exit = this._buildBlock(fn.body, cur);
+      this._callDepth--;
+      return exit === null ? this._addPlace('') : exit;
+    }
+    return this._buildOpaque(`${stmt.name}(${stmt.args})`, entry);
+  }
+
+  /**
+   * Emit a single unguarded transition with the given label for statements
+   * whose semantics are not modeled.
+   *
+   * @param {string} label - Label for the transition.
+   * @param {string} entry - Entry place id.
+   * @returns {string} Exit place id.
+   */
+  _buildOpaque(label, entry) {
+    const next = this._addPlace('');
+    const t = this._addTransition(label, null, null, false);
+    this._addArc(entry, t);
+    this._addArc(t, next);
+    return next;
+  }
+
+  /**
+   * Emit a return statement as a labeled transition terminating in a final place.
+   *
+   * @param {{expr: string|null}} stmt - Return AST.
+   * @param {string} entry - Entry place id.
+   * @returns {null} Always null; no fall-through.
+   */
+  _buildReturn(stmt, entry) {
+    const final = this._addPlace('end', 0);
+    this._dpn.getPlace(final).finalMarking = 1;
+    const t = this._addTransition('return', null, null, false);
+    this._addArc(entry, t);
+    this._addArc(t, final);
+    return null;
+  }
+
+  /**
+   * Emit a silent edge to the enclosing loop's exit or back place.
+   *
+   * @param {string} entry - Entry place id.
+   * @param {'break'|'continue'} kind - Jump kind.
+   * @returns {null} Always null; no fall-through.
+   */
+  _buildJump(entry, kind) {
+    const loop = this._loopStack[this._loopStack.length - 1];
+    if (!loop) return entry;
+    const target = kind === 'break' ? loop.exit : loop.back;
+    const t = this._addTransition(`[${kind}]`, null, null, true);
+    this._addArc(entry, t);
+    this._addArc(t, target);
+    return null;
+  }
+
+  /**
+   * Split a call's argument string on top-level commas, honoring nested
+   * parentheses and brackets.
+   *
+   * @param {string} args - Raw content between the call's parentheses.
+   * @returns {Array<string>} Trimmed argument expressions.
+   */
+  _splitArgs(args) {
+    const out = [];
+    let depth = 0;
+    let current = '';
+    for (const c of args) {
+      if (c === '(' || c === '[' || c === '{') depth++;
+      else if (c === ')' || c === ']' || c === '}') depth--;
+      if (c === ',' && depth === 0) {
+        if (current.trim()) out.push(current.trim());
+        current = '';
+      } else {
+        current += c;
+      }
+    }
+    if (current.trim()) out.push(current.trim());
+    return out;
+  }
+
+  /**
+   * Translate a Python expression into the YAPNE restricted infix form.
+   *
+   * @param {string} expr - Python expression as source text.
+   * @returns {string} Translated expression.
+   */
+  _translateExpr(expr) {
+    let e = expr;
+    e = e.replace(/\bTrue\b/g, 'true');
+    e = e.replace(/\bFalse\b/g, 'false');
+    e = e.replace(/\bNone\b/g, 'false');
+    e = e.replace(/\/\//g, '/');
+    return e;
+  }
+
+  /**
+   * Test whether a translated expression uses only constructs accepted by
+   * the YAPNE guard grammar.
+   *
+   * @param {string} expr - Translated expression.
+   * @returns {boolean} True if all constructs are representable.
+   */
+  _isSupported(expr) {
+    if (!expr) return false;
+    if (/\b(in|is)\b/.test(expr)) return false;
+    if (/%|\*\*/.test(expr)) return false;
+    if (/[\[\]\{\}]/.test(expr)) return false;
+    if (/['"]/.test(expr)) return false;
+    return true;
+  }
+
+  /**
+   * Guess the type of a Python right-hand side expression. First-write type
+   * wins and is kept for the lifetime of the variable.
+   *
+   * @param {string} expr - Right-hand side source text.
+   * @returns {string} One of 'int', 'float', 'boolean', 'string'.
+   */
+  _inferType(expr) {
+    if (!expr) return 'int';
+    const t = expr.trim();
+    if (/^(True|False|true|false)$/.test(t)) return 'boolean';
+    if (/^['"].*['"]$/.test(t)) return 'string';
+    if (/^[+-]?\d+\.\d+/.test(t)) return 'float';
+    if (/\b(and|or|not)\b|[<>!]=|==|[<>]/.test(t)) return 'boolean';
+    return 'int';
+  }
+
+  /**
+   * Return the default initial value for a given DataVariable type.
+   *
+   * @param {string} type - One of 'int', 'float', 'boolean', 'string'.
+   * @returns {number|boolean|string} The default initial value.
+   */
+  _defaultValue(type) {
+    switch (type) {
+      case 'float':   return 0.0;
+      case 'boolean': return false;
+      case 'string':  return '';
+      default:        return 0;
+    }
+  }
+
+  /**
+   * Register a data variable, keeping the first-seen type.
+   *
+   * @param {string} name - Variable name.
+   * @param {string} type - Inferred variable type.
+   * @returns {void}
+   */
+  _ensureVariable(name, type) {
+    if (!this._variables.has(name)) this._variables.set(name, type);
+  }
+
+  /**
+   * Apply generalization to a precondition. Returns null (no guard) once
+   * generalization crosses the precondition-drop threshold.
+   *
+   * @param {string|null} guard - The raw guard expression or null.
+   * @returns {string|null} The kept guard or null.
+   */
+  _generalizePre(guard) {
+    if (!guard) return null;
+    return this.generalization >= 0.8 ? null : guard;
+  }
+
+  /**
+   * Apply generalization to a postcondition. Returns null (no effect) once
+   * generalization crosses the postcondition-drop threshold.
+   *
+   * @param {string|null} post - The raw postcondition expression or null.
+   * @returns {string|null} The kept postcondition or null.
+   */
+  _generalizePost(post) {
+    if (!post) return null;
+    return this.generalization >= 0.4 ? null : post;
+  }
+
+  /**
+   * Add a Place to the DPN at an auto-advanced grid position.
+   *
+   * @param {string} label - Label for the place.
+   * @param {number} [tokens=0] - Initial token count.
+   * @returns {string} Id of the new place.
+   */
+  _addPlace(label, tokens = 0) {
+    const id = this._uuid();
+    this._gridX += 80;
+    this._dpn.addPlace(new Place(id, { x: this._gridX, y: this._gridY }, label, tokens));
+    return id;
+  }
+
+  /**
+   * Add a Transition to the DPN. A DataAwareTransition is used when either
+   * a precondition or postcondition is provided; otherwise a plain Transition.
+   *
+   * @param {string} label - Transition label.
+   * @param {string|null} pre - Precondition expression or null.
+   * @param {string|null} post - Postcondition expression or null.
+   * @param {boolean} [silent=false] - Whether the transition is tau.
+   * @returns {string} Id of the new transition.
+   */
+  _addTransition(label, pre, post, silent = false) {
+    const id = this._uuid();
+    this._gridX += 80;
+    const pos = { x: this._gridX, y: this._gridY };
+    const t = (pre || post)
+      ? new DataAwareTransition(id, pos, label, 1, 0, pre || '', post || '', silent)
+      : new Transition(id, pos, label, 1, 0, silent);
+    this._dpn.addTransition(t);
+    return id;
+  }
+
+  /**
+   * Add a regular-type Arc with weight 1 between two DPN elements.
+   *
+   * @param {string} source - Source element id.
+   * @param {string} target - Target element id.
+   * @returns {string} Id of the new arc.
+   */
+  _addArc(source, target) {
+    const id = this._uuid();
+    this._dpn.addArc(new Arc(id, source, target, 1, 'regular'));
+    return id;
+  }
+
+  /**
+   * Generate a UUID v4 string.
+   *
+   * @returns {string} A freshly generated UUID.
+   */
+  _uuid() {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+      const r = Math.random() * 16 | 0;
+      const v = c === 'x' ? r : (r & 0x3 | 0x8);
+      return v.toString(16);
+    });
+  }
+}
+
+
+export { PythonToDPN };


### PR DESCRIPTION
Introduce a Python import workflow and a new guard-language pipeline. Adds a PythonImportDialog UI (button + stylesheet) and Python DPN transpiler (src/extensions/python-import-dialog.js, src/extensions/python-dpn-transpiler.js, styles/python-importer.css, tests/python-dpn-transpiler.js) and wires the dialog into app.js. Implements guard-language tooling (lexer, parser, evaluator, smt-emitter, validator, migrator) under src/extensions/guard-language and updates DPN extensions and soundness verifier to integrate the new format. Adds a migration script (scripts/migrate-examples.mjs) and updates many example JSONs to the new guard-language syntax/formatting and normalized types/expressions.