### PR TITLE
remove semicolons from Fibonacci example expressions

### DIFF
--- a/public/examples/DPN-Fibonacci(n).json
+++ b/public/examples/DPN-Fibonacci(n).json
@@ -109,7 +109,7 @@
       "isEnabled": false,
       "priority": 1,
       "delay": 0,
-      "precondition": "i < n;",
+      "precondition": "i < n",
       "postcondition": ""
     },
     {
@@ -124,7 +124,7 @@
       "isEnabled": false,
       "priority": 1,
       "delay": 0,
-      "precondition": "i >= n;",
+      "precondition": "i >= n",
       "postcondition": "result' = b"
     },
     {


### PR DESCRIPTION
Very small PR; the Fibonacci example was broken due to unexpected semicolons in the expressions.